### PR TITLE
Remove usage of Dart 1 upper-case constants.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 sudo: false
 dart:
-  - stable
+  - dev
 script:
   - pub get --packages-dir
   - pub run dependency_validator --ignore dart_style,coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.9
+
+* Remove usage of Dart 1 upper-case constants.
+* Update SDK to a Dart 2.0 development branch.
+
 ## 1.0.8
 
 * Code cleanup

--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -174,7 +174,7 @@ main(List<String> args) {
   }
 
   completer.future.then((schemaText) {
-    Future schema = Schema.createSchema(convert.JSON.decode(schemaText));
+    Future schema = Schema.createSchema(convert.jsonDecode(schemaText));
     schema.then((schema) {
       String dot = createDot(schema);
       if (options['out-file'] != null) {

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -70,7 +70,7 @@ main() {
   //////////////////////////////////////////////////////////////////////
   url = "grades_schema.json";
   Schema.createSchemaFromUrl(url).then((schema) {
-    var grades = convert.JSON.decode('''
+    var grades = convert.jsonDecode('''
 {
     "semesters": [
         {

--- a/lib/src/json_schema/schema.dart
+++ b/lib/src/json_schema/schema.dart
@@ -114,21 +114,21 @@ class Schema {
         return request.close();
       }).then((HttpClientResponse response) {
         return response.transform(new convert.Utf8Decoder()).join().then((schemaText) {
-          Map map = convert.JSON.decode(schemaText);
+          Map map = convert.jsonDecode(schemaText);
           return createSchema(map);
         });
       });
     } else if (uri.scheme == 'file' || uri.scheme == '') {
       return new File(uri.scheme == 'file' ? uri.toFilePath() : schemaUrl)
           .readAsString()
-          .then((text) => createSchema(convert.JSON.decode(text)));
+          .then((text) => createSchema(convert.jsonDecode(text)));
     } else {
       throw new FormatException("Url schemd must be http, file, or empty: $schemaUrl");
     }
   }
 
   /// Create a schema from a [data]
-  ///  Typically [data] is result of JSON.decode(jsonSchemaString)
+  ///  Typically [data] is result of jsonDecode(jsonSchemaString)
   static Future<Schema> createSchema(Map data) => new Schema._fromRootMap(data)._thisCompleter.future;
 
   /// Validate [instance] against this schema

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 1.0.8
+version: 1.0.9
 
 authors:
   - Michael Carter <michael.carter@workiva.com>
@@ -9,7 +9,7 @@ homepage: https://github.com/workiva/json_schema
 description: >
   Provide support for validating instances against json schema
 environment:
-  sdk: ">=1.8.2 <2.0.0"
+  sdk: ">=2.0.0-dev.49.0 <3.0.0"
 
 dependencies:
   args: ">=0.11.0 <2.0.0"

--- a/test/unit/vm/json_schema/invalid_schemas_test.dart
+++ b/test/unit/vm/json_schema/invalid_schemas_test.dart
@@ -59,7 +59,7 @@ void main([List<String> args]) {
     String shortName = path.basename(testEntry.path);
     group("Invalid schema: ${shortName}", () {
       if (testEntry is File) {
-        List tests = convert.JSON.decode((testEntry as File).readAsStringSync());
+        List tests = convert.jsonDecode((testEntry as File).readAsStringSync());
         tests.forEach((testObject) {
           var schemaData = testObject["schema"];
           var description = testObject["description"];

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -84,7 +84,7 @@ void main([List<String> args]) {
           'refRemote.json', // seems to require webserver running to vend files
         ].contains(path.basename(testEntry.path))) return;
 
-        List tests = convert.JSON.decode((testEntry as File).readAsStringSync());
+        List tests = convert.jsonDecode((testEntry as File).readAsStringSync());
         tests.forEach((testEntry) {
           var schemaData = testEntry["schema"];
           var description = testEntry["description"];


### PR DESCRIPTION
## Ultimate problem:

Usage of deprecated constants, which will be removed in Dart 2.

## How it was fixed:

Change to using the corresponding camelCased constants or helper methods.
Requires update of SDK to a 2.0 dev release.

## Testing suggestions:

Test that it still works.

## Potential areas of regression:

Cannot be used with Dart 1 any more.

---

> __FYA:__ @michaelcarter-wf