### PR TITLE
EPL-8486: Allow Consumers to Specify a Custom $ref Resolver

### DIFF
--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -40,3 +40,4 @@ export 'package:json_schema/src/json_schema/json_schema.dart' show JsonSchema;
 export 'package:json_schema/src/json_schema/constants.dart' show JsonSchemaVersions;
 export 'package:json_schema/src/json_schema/schema_type.dart' show SchemaType;
 export 'package:json_schema/src/json_schema/validator.dart' show Validator;
+export 'package:json_schema/src/json_schema/typedefs.dart' show RefProvider, RefProviderAsync;

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -78,12 +78,24 @@ class JsonSchema {
     _addSchemaToRefMap(path, this);
   }
 
-  JsonSchema._fromRootMap(this._schemaMap, String schemaVersion, {Uri fetchedFromUri, bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
-    _initialize(schemaVersion: schemaVersion, fetchedFromUri: fetchedFromUri, isSync: isSync, refProvider: refProvider, refProviderAsync: refProviderAsync);
+  JsonSchema._fromRootMap(this._schemaMap, String schemaVersion,
+      {Uri fetchedFromUri, bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
+    _initialize(
+        schemaVersion: schemaVersion,
+        fetchedFromUri: fetchedFromUri,
+        isSync: isSync,
+        refProvider: refProvider,
+        refProviderAsync: refProviderAsync);
   }
 
-  JsonSchema._fromRootBool(this._schemaBool, String schemaVersion, {Uri fetchedFromUri, bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
-    _initialize(schemaVersion: schemaVersion, fetchedFromUri: fetchedFromUri, isSync: isSync, refProvider: refProvider, refProviderAsync: refProviderAsync);
+  JsonSchema._fromRootBool(this._schemaBool, String schemaVersion,
+      {Uri fetchedFromUri, bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
+    _initialize(
+        schemaVersion: schemaVersion,
+        fetchedFromUri: fetchedFromUri,
+        isSync: isSync,
+        refProvider: refProvider,
+        refProviderAsync: refProviderAsync);
   }
 
   /// Create a schema from a JSON [data].
@@ -95,16 +107,23 @@ class JsonSchema {
   /// [createSchema] remote references are not supported.
   ///
   /// Typically the supplied JSON [data] is result of [JSON.decode] on a JSON [String].
-  static Future<JsonSchema> createSchemaAsync(dynamic data, {String schemaVersion, Uri fetchedFromUri, RefProviderAsync refProvider}) {
+  static Future<JsonSchema> createSchemaAsync(dynamic data,
+      {String schemaVersion, Uri fetchedFromUri, RefProviderAsync refProvider}) {
     /// Set the Schema version before doing anything else, since almost everything depends on it.
     final version = _getSchemaVersion(schemaVersion, data);
 
     if (data is Map) {
-      return new JsonSchema._fromRootMap(data, schemaVersion, fetchedFromUri: fetchedFromUri, refProviderAsync: refProvider)._thisCompleter.future;
+      return new JsonSchema._fromRootMap(data, schemaVersion,
+              fetchedFromUri: fetchedFromUri, refProviderAsync: refProvider)
+          ._thisCompleter
+          .future;
 
       // Boolean schemas are only supported in draft 6 and later.
     } else if (data is bool && version == JsonSchemaVersions.draft6) {
-      return new JsonSchema._fromRootBool(data, schemaVersion, fetchedFromUri: fetchedFromUri, refProviderAsync: refProvider)._thisCompleter.future;
+      return new JsonSchema._fromRootBool(data, schemaVersion,
+              fetchedFromUri: fetchedFromUri, refProviderAsync: refProvider)
+          ._thisCompleter
+          .future;
     }
     throw new ArgumentError(
         'Data provided to createSchema is not valid: Must be a Map (or bool in draft6 or later). | $data');
@@ -121,12 +140,14 @@ class JsonSchema {
     final version = _getSchemaVersion(schemaVersion, data);
 
     if (data is Map) {
-      return new JsonSchema._fromRootMap(data, schemaVersion, fetchedFromUri: fetchedFromUri, isSync: true, refProvider: refProvider)
+      return new JsonSchema._fromRootMap(data, schemaVersion,
+              fetchedFromUri: fetchedFromUri, isSync: true, refProvider: refProvider)
           .resolvePath('#');
 
       // Boolean schemas are only supported in draft 6 and later.
     } else if (data is bool && version == JsonSchemaVersions.draft6) {
-      return new JsonSchema._fromRootBool(data, schemaVersion, fetchedFromUri: fetchedFromUri, isSync: true, refProvider: refProvider)
+      return new JsonSchema._fromRootBool(data, schemaVersion,
+              fetchedFromUri: fetchedFromUri, isSync: true, refProvider: refProvider)
           .resolvePath('#');
     }
     throw new ArgumentError(
@@ -145,7 +166,12 @@ class JsonSchema {
   }
 
   /// Construct and validate a JsonSchema.
-  _initialize({String schemaVersion, Uri fetchedFromUri, bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
+  _initialize(
+      {String schemaVersion,
+      Uri fetchedFromUri,
+      bool isSync = false,
+      RefProvider refProvider,
+      RefProviderAsync refProviderAsync}) {
     if (_root == null) {
       /// Set the Schema version before doing anything else, since almost everything depends on it.
       final version = _getSchemaVersion(schemaVersion, this._schemaMap);
@@ -1118,11 +1144,11 @@ class JsonSchema {
         return _addSchemaToRefMap(originalRef.toString(), schema);
       };
 
-      final AsyncRetrievalOperation asyncRefSchemaOperation =
-          _refProviderAsync == null ? () => createSchemaFromUrl(_ref.toString()).then(addSchemaFunction) :
-          () => _refProviderAsync(_ref.toString()).then(addSchemaFunction);
+      final AsyncRetrievalOperation asyncRefSchemaOperation = _refProviderAsync == null
+          ? () => createSchemaFromUrl(_ref.toString()).then(addSchemaFunction)
+          : () => _refProviderAsync(_ref.toString()).then(addSchemaFunction);
 
-      final SyncRetrievalOperation syncRefSchemaOperation = 
+      final SyncRetrievalOperation syncRefSchemaOperation =
           _refProvider != null ? () => addSchemaFunction(_refProvider(_ref.toString())) : null;
 
       /// Always add sub-schema retrieval requests to the [_root], as this is where the promise resolves.

--- a/lib/src/json_schema/typedefs.dart
+++ b/lib/src/json_schema/typedefs.dart
@@ -40,3 +40,5 @@ import 'dart:async';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 
 typedef Future<JsonSchema> CreateJsonSchemaFromUrl(String schemaUrl, {String schemaVersion});
+typedef JsonSchema RefProvider(String ref);
+typedef Future<JsonSchema> RefProviderAsync(String ref);

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -117,7 +117,8 @@ void main([List<String> args]) {
                 bool validationResult;
                 final bool expectedResult = validationTest['valid'];
                 if (isSync) {
-                  final schema = JsonSchema.createSchema(schemaData, schemaVersion: schemaVersion, refProvider: refProvider);
+                  final schema =
+                      JsonSchema.createSchema(schemaData, schemaVersion: schemaVersion, refProvider: refProvider);
                   validationResult = schema.validate(instance);
                   expect(validationResult, expectedResult);
                 } else {
@@ -136,7 +137,7 @@ void main([List<String> args]) {
   };
 
   final RefProvider syncRefProvider = (String ref) {
-    switch(ref) {
+    switch (ref) {
       case 'http://localhost:1234/integer.json':
         return JsonSchema.createSchema(convert.JSON.decode(r'''
           {
@@ -212,8 +213,10 @@ void main([List<String> args]) {
 
   runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
   runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
-  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, syncSkippedFiles, syncSkippedTests, isSync: true, refProvider: syncRefProvider);
-  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, syncSkippedFiles, syncSkippedTests, isSync: true, refProvider: syncRefProvider);
+  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, syncSkippedFiles, syncSkippedTests,
+      isSync: true, refProvider: syncRefProvider);
+  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, syncSkippedFiles, syncSkippedTests,
+      isSync: true, refProvider: syncRefProvider);
 
   group('Schema self validation', () {
     for (final version in JsonSchemaVersions.allVersions) {

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -85,7 +85,7 @@ void main([List<String> args]) {
 
   final runAllTestsForDraftX =
       (String schemaVersion, List<FileSystemEntity> allTests, List<String> skipFiles, List<String> skipTests,
-          {bool isSync = false, RefProvider refProvider}) {
+          {bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
     String shortSchemaVersion = schemaVersion;
     if (schemaVersion == JsonSchemaVersions.draft4) {
       shortSchemaVersion = 'draft4';
@@ -123,7 +123,7 @@ void main([List<String> args]) {
                   expect(validationResult, expectedResult);
                 } else {
                   final checkResult = expectAsync0(() => expect(validationResult, expectedResult));
-                  JsonSchema.createSchemaAsync(schemaData, schemaVersion: schemaVersion).then((schema) {
+                  JsonSchema.createSchemaAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProviderAsync).then((schema) {
                     validationResult = schema.validate(instance);
                     checkResult();
                   });
@@ -136,6 +136,7 @@ void main([List<String> args]) {
     });
   };
 
+  // Mock Ref Provider for refRemote tests. Emulates what createSchemaFromUrl would return.
   final RefProvider syncRefProvider = (String ref) {
     switch (ref) {
       case 'http://localhost:1234/integer.json':
@@ -201,22 +202,31 @@ void main([List<String> args]) {
     }
   };
 
+  final RefProviderAsync asyncRefProvider = (String ref) async {
+    // Mock a delayed response.
+    await new Duration(milliseconds: 1);
+    return syncRefProvider(ref);
+  };
+
   final List<String> commonSkippedFiles = const [];
 
   final List<String> commonSkippedTests = const [];
 
-  final List<String> syncSkippedFiles = const [
-    // 'refRemote.json',
-  ];
-
-  final List<String> syncSkippedTests = const [];
-
+  // Run all tests asynchronously with no ref provider.
   runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
   runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
-  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, syncSkippedFiles, syncSkippedTests,
+
+  // Run all tests synchronously with a sync ref provider.
+  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
       isSync: true, refProvider: syncRefProvider);
-  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, syncSkippedFiles, syncSkippedTests,
+  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
       isSync: true, refProvider: syncRefProvider);
+
+  // Run all tests asynchronously with an async ref provider.
+  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
+      refProviderAsync: asyncRefProvider);
+  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
+      refProviderAsync: asyncRefProvider);
 
   group('Schema self validation', () {
     for (final version in JsonSchemaVersions.allVersions) {

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -123,7 +123,9 @@ void main([List<String> args]) {
                   expect(validationResult, expectedResult);
                 } else {
                   final checkResult = expectAsync0(() => expect(validationResult, expectedResult));
-                  JsonSchema.createSchemaAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProviderAsync).then((schema) {
+                  JsonSchema
+                      .createSchemaAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProviderAsync)
+                      .then((schema) {
                     validationResult = schema.validate(instance);
                     checkResult();
                   });


### PR DESCRIPTION
## Ultimate problem:
- json_schema can only retrieve remote refs asynchronously from HTTP(S) URLs.

## How it was fixed:
- allow the consumer to pass in sync and async ref providers.

## Testing suggestions:
- ddev test
- CI

## Potential areas of regression:
- ref resolution