### PR TITLE
fix a Completer's type

### DIFF
--- a/lib/src/json_schema/schema.dart
+++ b/lib/src/json_schema/schema.dart
@@ -607,7 +607,7 @@ class Schema {
 
   /// Maps any non-key top level property to its original value
   Map<String, dynamic> _freeFormMap = {};
-  Completer _thisCompleter = new Completer();
+  Completer<Schema> _thisCompleter = new Completer<Schema>();
   List<Future<Schema>> _retrievalRequests = [];
 
   /// Set of strings to gaurd against path cycles


### PR DESCRIPTION
Fix a strong mode at runtime issue, where a signature was declared to return a `Future<Schema>`, but at runtime we were returning a `Future<dynamic>`.

If this looks good, do you mind doing a package publish? This library is consumed by the Flutter command line tool, and a publish would help us make it strong mode clean. Thanks!
