### PR TITLE
Make compatible with Dart 1 and Dart 2 constant names

### DIFF
--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -49,6 +49,7 @@ import 'dart:async';
 import 'dart:convert' as convert;
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/schema_dot.dart';
 import 'package:logging/logging.dart';
@@ -171,7 +172,7 @@ main(List<String> args) {
   }
 
   completer.future.then((schemaText) {
-    final Future schema = JsonSchema.createSchemaAsync(convert.JSON.decode(schemaText));
+    final Future schema = JsonSchema.createSchemaAsync(convert2.json.decode(schemaText));
     schema.then((schema) {
       final String dot = createDot(schema);
       if (options['out-file'] != null) {

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -37,7 +37,7 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'dart:convert' as convert;
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:json_schema/json_schema.dart';
 import 'package:logging/logging.dart';
 
@@ -70,7 +70,7 @@ main() {
   //////////////////////////////////////////////////////////////////////
   url = 'grades_schema.json';
   JsonSchema.createSchemaFromUrl(url).then((schema) {
-    final grades = convert.JSON.decode('''
+    final grades = convert.json.decode('''
 {
     'semesters': [
         {

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -35,7 +35,8 @@
 //     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
-import 'dart:convert';
+
+import 'package:dart2_constant/convert.dart';
 
 class JsonSchemaValidationRegexes {
   static RegExp email = new RegExp(r'^[_A-Za-z0-9-\+]+(\.[_A-Za-z0-9-]+)*'
@@ -96,7 +97,7 @@ Map getJsonSchemaDefinitionByRef(String ref) {
 }
 
 class JsonSchemaDefinitions {
-  static Map draft4 = JSON.decode(r'''
+  static Map draft4 = json.decode(r'''
     {
     "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -248,7 +249,7 @@ class JsonSchemaDefinitions {
 }
     ''');
 
-  static Map draft6 = JSON.decode(r'''
+  static Map draft6 = json.decode(r'''
     {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://json-schema.org/draft-06/schema#",

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -37,7 +37,6 @@
 //     THE SOFTWARE.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:path/path.dart' as path_lib;
 

--- a/lib/src/json_schema/vm/platform_functions.dart
+++ b/lib/src/json_schema/vm/platform_functions.dart
@@ -40,6 +40,7 @@ import 'dart:io';
 import 'dart:async';
 import 'dart:convert' as convert;
 
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'package:json_schema/src/json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/utils.dart';
 
@@ -58,10 +59,10 @@ Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {String schemaVersion
       throw new ArgumentError('Schema at URL: $schemaUrl can\'t be found.');
     }
     final schemaText = await response.transform(new convert.Utf8Decoder()).join();
-    schemaMap = convert.JSON.decode(schemaText);
+    schemaMap = convert2.json.decode(schemaText);
   } else if (uri.scheme == 'file' || uri.scheme == '') {
     final fileString = await new File(uri.scheme == 'file' ? uri.toFilePath() : schemaUrl).readAsString();
-    schemaMap = convert.JSON.decode(fileString);
+    schemaMap = convert2.json.decode(fileString);
   } else {
     throw new FormatException('Url schema must be http, file, or empty: $schemaUrl');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: https://github.com/workiva/json_schema
 description: >
   Provide support for validating instances against json schema
 environment:
-  sdk: '>=1.8.2 <3.0.0'
+  sdk: '>=1.24.0 <3.0.0'
 
 dependencies:
   args: '>=0.11.0 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 
 dependencies:
   args: '>=0.11.0 <2.0.0'
+  dart2_constant: ^1.0.0
   logging: '>=0.9.3<0.12.0'
   path: '^1.3.0'
   uri_template: ^0.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: https://github.com/workiva/json_schema
 description: >
   Provide support for validating instances against json schema
 environment:
-  sdk: '>=1.8.2 <2.0.0'
+  sdk: '>=1.8.2 <3.0.0'
 
 dependencies:
   args: '>=0.11.0 <2.0.0'

--- a/test/unit/vm/json_schema/invalid_schemas_test.dart
+++ b/test/unit/vm/json_schema/invalid_schemas_test.dart
@@ -38,9 +38,9 @@
 
 library json_schema.test_invalid_schemas;
 
-import 'dart:convert' as convert;
 import 'dart:io';
 
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -64,7 +64,7 @@ void main([List<String> args]) {
     final String shortName = path.basename(testEntry.path);
     group('Invalid schema (draft4): ${shortName}', () {
       if (testEntry is File) {
-        final List tests = convert.JSON.decode((testEntry).readAsStringSync());
+        final List tests = convert.json.decode((testEntry).readAsStringSync());
         tests.forEach((testObject) {
           final schemaData = testObject['schema'];
           final description = testObject['description'];

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -38,8 +38,8 @@
 
 library json_schema.test_validation;
 
-import 'dart:convert' as convert;
 import 'dart:io';
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/vm.dart';
 import 'package:json_schema/src/json_schema/constants.dart';
@@ -99,7 +99,7 @@ void main([List<String> args]) {
           // Skip these for now - reason shown.
           if (skipFiles.contains(path.basename(testEntry.path))) return;
 
-          final List tests = convert.JSON.decode((testEntry).readAsStringSync());
+          final List tests = convert.json.decode((testEntry).readAsStringSync());
           tests.forEach((testEntry) {
             final schemaData = testEntry['schema'];
             final description = testEntry['description'];
@@ -142,14 +142,14 @@ void main([List<String> args]) {
   final RefProvider syncRefProvider = (String ref) {
     switch (ref) {
       case 'http://localhost:1234/integer.json':
-        return JsonSchema.createSchema(convert.JSON.decode(r'''
+        return JsonSchema.createSchema(convert.json.decode(r'''
           {
             "type": "integer"
           }
         '''));
         break;
       case 'http://localhost:1234/subSchemas.json#/integer':
-        return JsonSchema.createSchema(convert.JSON.decode(r'''
+        return JsonSchema.createSchema(convert.json.decode(r'''
           {
             "integer": {
               "type": "integer"
@@ -161,7 +161,7 @@ void main([List<String> args]) {
         ''')).resolvePath('#/integer');
         break;
       case 'http://localhost:1234/subSchemas.json#/refToInteger':
-        return JsonSchema.createSchema(convert.JSON.decode(r'''
+        return JsonSchema.createSchema(convert.json.decode(r'''
           {
             "integer": {
               "type": "integer"
@@ -173,14 +173,14 @@ void main([List<String> args]) {
         ''')).resolvePath('#/refToInteger');
         break;
       case 'http://localhost:1234/folder/folderInteger.json':
-        return JsonSchema.createSchema(convert.JSON.decode(r'''
+        return JsonSchema.createSchema(convert.json.decode(r'''
           {
             "type": "integer"
           }
         '''));
         break;
       case 'http://localhost:1234/name.json#/definitions/orNull':
-        return JsonSchema.createSchema(convert.JSON.decode(r'''
+        return JsonSchema.createSchema(convert.json.decode(r'''
           {
             "definitions": {
               "orNull": {


### PR DESCRIPTION
## Ultimate problem:

SCREAMING CAPS constants have been removed as of Dart 2.0.0-dev.69.2 .  This package will no longer work with any dev or stable releases going forward without fixes.  

## How it was fixed:

This PR uses the dart2_constant package to fix this in a way that is still backwards compatible with Dart 1.  References to constants that have changed their names in Dart 2 are re-directed through the dart_constant package which uses pub version solving to back this with the appropriate SDK constants.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf