### PR TITLE
fix constants for dart 1 and dart 2 compat based off 1.0.9

### DIFF
--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -46,7 +46,8 @@
 /// the file, otherwise written to stdout.
 ///
 import 'dart:async';
-import 'dart:convert' as convert;
+import 'dart:convert';
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'dart:io';
 import 'package:args/args.dart';
 import 'package:json_schema/json_schema.dart';
@@ -162,7 +163,7 @@ main(List<String> args) {
     new HttpClient()
         .getUrl(uri)
         .then((HttpClientRequest request) => request.close())
-        .then((HttpClientResponse response) => response.transform(new convert.Utf8Decoder()).join())
+        .then((HttpClientResponse response) => response.transform(new Utf8Decoder()).join())
         .then((text) {
       completer.complete(text);
     });
@@ -174,7 +175,7 @@ main(List<String> args) {
   }
 
   completer.future.then((schemaText) {
-    Future schema = Schema.createSchema(convert.JSON.decode(schemaText));
+    Future schema = Schema.createSchema(convert2.json.decode(schemaText));
     schema.then((schema) {
       String dot = createDot(schema);
       if (options['out-file'] != null) {

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -37,7 +37,7 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import "dart:convert" as convert;
+import 'package:dart2_constant/convert.dart' as convert2;
 import "package:json_schema/json_schema.dart";
 import "package:logging/logging.dart";
 
@@ -70,7 +70,7 @@ main() {
   //////////////////////////////////////////////////////////////////////
   url = "grades_schema.json";
   Schema.createSchemaFromUrl(url).then((schema) {
-    var grades = convert.JSON.decode('''
+    var grades = convert2.json.decode('''
 {
     "semesters": [
         {

--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -40,9 +40,10 @@
 library json_schema.json_schema;
 
 import 'dart:async';
-import 'dart:convert' as convert;
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as PATH;
 

--- a/lib/src/json_schema/schema.dart
+++ b/lib/src/json_schema/schema.dart
@@ -113,15 +113,15 @@ class Schema {
         request.followRedirects = true;
         return request.close();
       }).then((HttpClientResponse response) {
-        return response.transform(new convert.Utf8Decoder()).join().then((schemaText) {
-          Map map = convert.JSON.decode(schemaText);
+        return response.transform(new Utf8Decoder()).join().then((schemaText) {
+          Map map = convert2.json.decode(schemaText);
           return createSchema(map);
         });
       });
     } else if (uri.scheme == 'file' || uri.scheme == '') {
       return new File(uri.scheme == 'file' ? uri.toFilePath() : schemaUrl)
           .readAsString()
-          .then((text) => createSchema(convert.JSON.decode(text)));
+          .then((text) => createSchema(convert2.json.decode(text)));
     } else {
       throw new FormatException("Url schemd must be http, file, or empty: $schemaUrl");
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 1.0.9
+version: 1.0.10
 
 authors:
   - Michael Carter <michael.carter@workiva.com>
@@ -9,10 +9,11 @@ homepage: https://github.com/workiva/json_schema
 description: >
   Provide support for validating instances against json schema
 environment:
-  sdk: ">=1.8.2 <2.0.0"
+  sdk: ">=1.8.2 <3.0.0"
 
 dependencies:
   args: ">=0.11.0 <2.0.0"
+  dart2_constant: ^1.0.0
   logging: ">=0.9.3<0.12.0"
   path: "^1.3.0"
 

--- a/test/unit/vm/json_schema/invalid_schemas_test.dart
+++ b/test/unit/vm/json_schema/invalid_schemas_test.dart
@@ -38,7 +38,7 @@
 
 library json_schema.test_invalid_schemas;
 
-import 'dart:convert' as convert;
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'dart:io';
 import 'package:json_schema/json_schema.dart';
 import 'package:logging/logging.dart';
@@ -59,7 +59,7 @@ void main([List<String> args]) {
     String shortName = path.basename(testEntry.path);
     group("Invalid schema: ${shortName}", () {
       if (testEntry is File) {
-        List tests = convert.JSON.decode((testEntry as File).readAsStringSync());
+        List tests = convert2.json.decode((testEntry as File).readAsStringSync());
         tests.forEach((testObject) {
           var schemaData = testObject["schema"];
           var description = testObject["description"];

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -38,7 +38,7 @@
 
 library json_schema.test_validation;
 
-import 'dart:convert' as convert;
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'dart:io';
 import 'package:json_schema/json_schema.dart';
 import 'package:logging/logging.dart';
@@ -84,7 +84,7 @@ void main([List<String> args]) {
           'refRemote.json', // seems to require webserver running to vend files
         ].contains(path.basename(testEntry.path))) return;
 
-        List tests = convert.JSON.decode((testEntry as File).readAsStringSync());
+        List tests = convert2.json.decode((testEntry as File).readAsStringSync());
         tests.forEach((testEntry) {
           var schemaData = testEntry["schema"];
           var description = testEntry["description"];


### PR DESCRIPTION
## Ultimate problem:

SCREAMING CAPS constants have been removed as of Dart 2.0.0-dev.69.2 . This package will no longer work with any dev or stable releases going forward without fixes.

## How it was fixed:
This PR uses the dart2_constant package to fix this in a way that is still backwards compatible with Dart 1. References to constants that have changed their names in Dart 2 are re-directed through the dart_constant package which uses pub version solving to back this with the appropriate SDK constants.

## Testing suggestions:
 - [ ] CI passes

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf