### PR TITLE
WAP-1507 Final 2.0 Cleanup and Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.0.0
+
+* json_schema is no longer bound to dart:io and works in the browser!
+* Full JSON Schema draft6 compatibility
+* Much better $ref resolution, including deep nesting of $refs
+* More typed keyword getters for draft6 like `examples`
+* Syncronous schema evaluation by default 
+* Optional async evaluation and fetching with `createSchemaAsync`
+* Automatic parsing of JSON strings passed to `createSchema` and `createSchemaAsync`
+* Ability to do custom resolution of $refs with `RefProvider` and `RefProviderAsync`
+* Optional parsing of JSON strings passed to `validate` with `parseJson = true`
+* Dart 2.0 compatibility
+* Many small changes to make things more in line with modern dart.
+* Please see the [migration guide](./MIGRATION.md) for additional info.
+
 ## 1.0.8
 
 * Code cleanup

--- a/README.md
+++ b/README.md
@@ -4,126 +4,344 @@
 
 ![Build Status](https://travis-ci.org/workiva/json_schema.svg)
 
-## How To Create a Schema
+## How To Create and Validate Against a Schema
   
-### Synchronous Creation, no $refs (Default Behavior):
+### Synchronous Creation - Self Contained
   
-The simplest way to create a schema is to pass JSON data directly to `JsonSchema.createSchema` with a JSON `String`, or decoded JSON via Dart `Map` or `bool`.
+The simplest way to create a schema is to pass JSON data directly to `JsonSchema.createSchema` with a JSON `String`, or decoded JSON via Dart `Map` or `bool`. 
+
+After creating any schema, JSON instances can be validated by calling `.validate(instance)` on that schema. By default, instances are expected to be pre-parsed JSON as native dart primitives (`Map`, `List`, `String`, `bool`, `num`, `int`). You can also optionally parse at validation time by passing in a string and setting `parseJson`: `schema.validate('{ "name": "any JSON object"}', parseJson: true)`.
     
-    Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation".
-
-
-#### Example (Synchronous, Self-Contained Schema)
-
-A schema can be created with a Map that is either hand-crafted, referneced from a JSON file, or *previously* fetched from the network or file system.
-
-  ```dart
-/// Define schema in a Dart [Map] or use a JSON [String].
-var mustBeIntegerSchemaMap = {
-"type" : "integer"
-};
-
-// Create some examples to validate against the schema.
-var n = 3;
-var decimals = 3.14;
-var str = 'hi';
-
-// Construct the schema from the schema map or JSON string.
-final schema = JsonSchema.createSchema(mustBeIntegerSchema);
-
-print('$n => ${schema.validate(n)}'); // true
-print('$decimals => ${schema.validate(decimals)}'); // false
-print('$str => ${schema.validate(str)}'); // false
-  ```
-
-### Synchronous Creation, with locally cached $refs:
-
-If you want to create `JsonSchema`s synchronously, and you have $refs that cannot be resolved within the root schema, but you have a cache of those $ref'd schemas locally, you can write a `RefProvider` to get them during schema evaluation.
-
-### Asynchronous Creation, with remote HTTP $refs:
-
-If you have schemas that have nested $refs that are HTTP URIs that are publically accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well.
-
-#### Example 1 (createSchemaAsync)
-
-```dart
-// TODO
-```
-
-#### Example 2 (createSchemaFromUrl)
-
-```dart
-String url = "http://json-schema.org/draft-04/schema";
-final schema = await JsonSchema.createSchemaFromUrl(url)
-print('Does schema validate itself? ${schema.validate(schema.schemaMap)}');
-```
-
-    In this example a schema is created from the url and its stored
-    contents are validated against itself. Since the referenced schema
-    is the schema for schemas and the instance is, of course, a schema,
-    the result prints true.
-
-### Asynchronous Creation, with custom remote $refs:
-
-If you have nested $refs that are either non-HTTP URIs or non-publically-accessible HTTP $refs, you can supply an `AsyncRefProvider` to `createSchemaAsync`, and 
+    Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation" examples below.
 
 
 #### Example
 
+A schema can be created with a Map that is either hand-crafted, referneced from a JSON file, or *previously* fetched from the network or file system.
+
 ```dart
-// TODO
+import 'package:json_schema/json_schema.dart';
+
+main() {
+  /// Define schema in a Dart [Map] or use a JSON [String].
+  final mustBeIntegerSchemaMap = {"type": "integer"};
+
+  // Create some examples to validate against the schema.
+  final n = 3;
+  final decimals = 3.14;
+  final str = 'hi';
+
+  // Construct the schema from the schema map or JSON string.
+  final schema = JsonSchema.createSchema(mustBeIntegerSchemaMap);
+
+  print('$n => ${schema.validate(n)}'); // true
+  print('$decimals => ${schema.validate(decimals)}'); // false
+  print('$str => ${schema.validate(str)}'); // false
+}
 ```
 
+### Synchronous Creation, Local Ref Cache
 
-## How To Validate JSON againt a schema
+If you want to create `JsonSchema`s synchronously, and you have $refs that cannot be resolved within the root schema, but you have a cache of those $ref'd schemas locally, you can write a `RefProvider` to get them during schema evaluation.
 
-To validate instances against a `JsonSchema` first create the schema, then call validate on it with an json instance (Dart `Map` or JSON `String`). This can be done with an url:
+#### Example
 
-### Example 2
-  
-  An url can point to a local file, either of format
-  _file:///absolute\_path\_to/schema.json_ or _subfolder/schema.json_
-  where _subfolder_ is a subfolder of current working directory. An
-  example of this can be found in
-  _example/from\_url/validate\_instance\_from\_url.dart_
+```dart 
+import 'package:json_schema/json_schema.dart';
+import 'package:dart2_constant/convert.dart';
 
-      url = "grades_schema.json";
-      JsonSchema.createSchemaFromUrl(url)
-        .then((schema) {
-          var grades = JSON.parse('''
+main() {
+  final referencedSchema = {
+    r"$id": "https://example.com/geographical-location.schema.json",
+    r"$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Longitude and Latitude",
+    "description": "A geographical coordinate on a planet (most commonly Earth).",
+    "required": ["latitude", "longitude"],
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+      "longitude": {"type": "number", "minimum": -180, "maximum": 180}
+    }
+  };
+
+  final RefProvider refProvider = (String ref) {
+    final Map references = {
+      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
+    };
+
+    if (references.containsKey(ref)) {
+      return references[ref];
+    }
+
+    return null;
+  };
+
+  final schema = JsonSchema.createSchema({
+    'type': 'array',
+    'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
+  }, refProvider: refProvider);
+
+  final workivaLocations = [
     {
-        "semesters": [
-            {
-                "semester": 1,
-                "grades": [
-                    {
-                        "type": "homework",
-                        "date": "09/27/2013",
-                        "grade": 100,
-                        "avg": 93,
-                        "std": 8
-                    },
-                    {
-                        "type": "homework",
-                        "date": "09/28/2013",
-                        "grade": 100,
-                        "avg": 60,
-                        "std": 25
-                    }
-                ]  
-            }
-          ]
-    }''');
-          
-          print('''Does grades schema validate $grades
-      ${schema.validate(grades)}''');
+      'name': 'Ames',
+      'latitude': 41.9956731,
+      'longitude': -93.6403663,
+    },
+    {
+      'name': 'Scottsdale',
+      'latitude': 33.4634707,
+      'longitude': -111.9266617,
+    }
+  ];
 
-  In this example the schema is read from file _grades\_schema.json_
-  in the current directory and a valid instance is submitted for
-  validation (in the string of the print statement). This example also
-  prints true.
+  final badLocations = [
+    {
+      'name': 'Bad Badlands',
+      'latitude': 181,
+      'longitude': 92,
+    },
+    {
+      'name': 'Nowhereville',
+      'latitude': -2000,
+      'longitude': 7836,
+    }
+  ];
 
-# How To Use Schema Information
+  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+}
+```
+
+### Asynchronous Creation, Remote HTTP Refs
+
+If you have schemas that have nested $refs that are HTTP URIs that are publically accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well (see next example).
+
+#### Example
+
+```dart
+import 'dart:io';
+
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
+  configureJsonSchemaForVm();
+
+  // For Browser:
+  // configureJsonSchemaForBrowser();
+
+  // Schema Defined as a JSON String
+  final schema = await JsonSchema.createSchemaAsync(r'''
+  {
+    "type": "array",
+    "items": {
+      "$ref": "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json"
+    }
+  }
+  ''');
+
+  // Create some examples to validate against the schema.
+  final numbersArray = [1, 2, 3];
+  final decimalsArray = [3.14, 1.2, 5.8];
+  final strArray = ['hello', 'world'];
+
+  print('$numbersArray => ${schema.validate(numbersArray)}'); // true
+  print('$decimalsArray => ${schema.validate(decimalsArray)}'); // false
+  print('$strArray => ${schema.validate(strArray)}'); // false
+
+  // Exit the process cleanly (VM Only).
+  exit(0);
+}
+```
+
+### Asynchronous Creation, From URL or File
+
+You can also create a schema directly from a publically accessible URL, like so:
+
+#### Example 1 - URL
+
+```dart
+import 'dart:io';
+
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
+  configureJsonSchemaForVm();
+
+  // For Browser:
+  // configureJsonSchemaForBrowser();
+
+  final url = "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json";
+
+  final schema = await JsonSchema.createSchemaFromUrl(url);
+
+  // Create some examples to validate against the schema.
+  final n = 3;
+  final decimals = 3.14;
+  final str = 'hi';
+
+  print('$n => ${schema.validate(n)}'); // true
+  print('$decimals => ${schema.validate(decimals)}'); // false
+  print('$str => ${schema.validate(str)}'); // false
+
+  // Exit the process cleanly (VM Only).
+  exit(0);
+}
+```
+
+#### Example 2 - File
+
+```dart
+import 'dart:io';
+
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
+  configureJsonSchemaForVm();
+
+  // For Browser:
+  // configureJsonSchemaForBrowser();
+
+  final file = "example/readme/asynchronous_creation/geo.schema.json";
+
+  final schema = await JsonSchema.createSchemaFromUrl(file);
+
+  // Create some examples to validate against the schema.
+  final workivaAmes = {
+    'latitude': 41.9956731,
+    'longitude': -93.6403663,
+  };
+
+  final nowhereville = {
+    'latitude': -2000,
+    'longitude': 7836,
+  };
+
+  print('$workivaAmes => ${schema.validate(workivaAmes)}'); // true
+  print('$nowhereville => ${schema.validate(nowhereville)}'); // false
+
+  // Exit the process cleanly (VM Only).
+  exit(0);
+}
+```
+
+### Asynchronous Creation, with custom remote $refs:
+
+If you have nested $refs that are either non-HTTP URIs or non-publically-accessible HTTP $refs, you can supply an `RefProviderAsync` to `createSchemaAsync`, and perform any custom logic you need.
+
+#### Example
+
+```dart
+import 'dart:io';
+import 'dart:async';
+import 'package:dart2_constant/convert.dart';
+
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
+  configureJsonSchemaForVm();
+
+  // For Browser:
+  // configureJsonSchemaForBrowser();
+
+  final referencedSchema = {
+    r"$id": "https://example.com/geographical-location.schema.json",
+    r"$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Longitude and Latitude",
+    "description": "A geographical coordinate on a planet (most commonly Earth).",
+    "required": ["latitude", "longitude"],
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+      "longitude": {"type": "number", "minimum": -180, "maximum": 180}
+    }
+  };
+
+  final RefProviderAsync refProvider = (String ref) async {
+    final Map references = {
+      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
+    };
+
+    if (references.containsKey(ref)) {
+      // Silly example that adds a 1 second delay.
+      // In practice, you could make any service call here,
+      // parse the results into a schema, and return.
+      await new Future.delayed(new Duration(seconds: 1));
+      return references[ref];
+    }
+
+    // Fall back to default URL $ref behavior
+    return await JsonSchema.createSchemaFromUrl(ref);
+  };
+
+  final schema = await JsonSchema.createSchemaAsync({
+    'type': 'array',
+    'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
+  }, refProvider: refProvider);
+
+  final workivaLocations = [
+    {
+      'name': 'Ames',
+      'latitude': 41.9956731,
+      'longitude': -93.6403663,
+    },
+    {
+      'name': 'Scottsdale',
+      'latitude': 33.4634707,
+      'longitude': -111.9266617,
+    }
+  ];
+
+  final badLocations = [
+    {
+      'name': 'Bad Badlands',
+      'latitude': 181,
+      'longitude': 92,
+    },
+    {
+      'name': 'Nowhereville',
+      'latitude': -2000,
+      'longitude': 7836,
+    }
+  ];
+
+  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+
+  exit(0);
+}
+```
+
+## How To Use Schema Information
 
   Schema information can be used for validation; but it can also be a
   valuable source of information about the structure of data. The

--- a/README.md
+++ b/README.md
@@ -1,28 +1,83 @@
-# Json Schema
+# JSON Schema
 
-  A *dart:io* dependent library for validating json instances against json schema (version Draft 04)
+  A *platform agnostic* (dart:html or dart:io) Dart library for validating JSON instances against JSON Schemas (multi-version support with latest of Draft 6).
 
 ![Build Status](https://travis-ci.org/workiva/json_schema.svg)
 
+## How To Create a Schema
+  
+### Synchronous Creation, no $refs (Default Behavior):
+  
+The simplest way to create a schema is to pass JSON data directly to `JsonSchema.createSchema` with a JSON `String`, or decoded JSON via Dart `Map` or `bool`.
+    
+    Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation".
 
-# How To Validate
 
-  To validate instances against a schema first create the schema, then
-  call validate on it with an json instance. This can be done with an
-  url:
+#### Example (Synchronous, Self-Contained Schema)
 
-### Example 1  
+A schema can be created with a Map that is either hand-crafted, referneced from a JSON file, or *previously* fetched from the network or file system.
 
-    String url = "http://json-schema.org/draft-04/schema";
-    JsonSchema.createSchemaFromUrl(url)
-      .then((schema) {
-        print('Does schema validate itself? ${schema.validate(schema.schemaMap)}');
-      });
+  ```dart
+/// Define schema in a Dart [Map] or use a JSON [String].
+var mustBeIntegerSchemaMap = {
+"type" : "integer"
+};
 
-  In this example a schema is created from the url and its stored
-  contents are validated against itself. Since the referenced schema
-  is the schema for schemas and the instance is, of course, a schema,
-  the result prints true.
+// Create some examples to validate against the schema.
+var n = 3;
+var decimals = 3.14;
+var str = 'hi';
+
+// Construct the schema from the schema map or JSON string.
+final schema = JsonSchema.createSchema(mustBeIntegerSchema);
+
+print('$n => ${schema.validate(n)}'); // true
+print('$decimals => ${schema.validate(decimals)}'); // false
+print('$str => ${schema.validate(str)}'); // false
+  ```
+
+### Synchronous Creation, with locally cached $refs:
+
+If you want to create `JsonSchema`s synchronously, and you have $refs that cannot be resolved within the root schema, but you have a cache of those $ref'd schemas locally, you can write a `RefProvider` to get them during schema evaluation.
+
+### Asynchronous Creation, with remote HTTP $refs:
+
+If you have schemas that have nested $refs that are HTTP URIs that are publically accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well.
+
+#### Example 1 (createSchemaAsync)
+
+```dart
+// TODO
+```
+
+#### Example 2 (createSchemaFromUrl)
+
+```dart
+String url = "http://json-schema.org/draft-04/schema";
+final schema = await JsonSchema.createSchemaFromUrl(url)
+print('Does schema validate itself? ${schema.validate(schema.schemaMap)}');
+```
+
+    In this example a schema is created from the url and its stored
+    contents are validated against itself. Since the referenced schema
+    is the schema for schemas and the instance is, of course, a schema,
+    the result prints true.
+
+### Asynchronous Creation, with custom remote $refs:
+
+If you have nested $refs that are either non-HTTP URIs or non-publically-accessible HTTP $refs, you can supply an `AsyncRefProvider` to `createSchemaAsync`, and 
+
+
+#### Example
+
+```dart
+// TODO
+```
+
+
+## How To Validate JSON againt a schema
+
+To validate instances against a `JsonSchema` first create the schema, then call validate on it with an json instance (Dart `Map` or JSON `String`). This can be done with an url:
 
 ### Example 2
   
@@ -67,36 +122,6 @@
   in the current directory and a valid instance is submitted for
   validation (in the string of the print statement). This example also
   prints true.
-
-### Example 3
-
-  A schema can be created with a Map that is either hand-crafted or
-  the result of a call to json parse.
-
-      //////////////////////////////////////////////////////////////////////
-      // Define schema in code
-      //////////////////////////////////////////////////////////////////////
-      var mustBeIntegerSchema = {
-        "type" : "integer"
-      };
-    
-      var n = 3;
-      var decimals = 3.14;
-      var str = 'hi';
-    
-      JsonSchema.createSchema(mustBeIntegerSchema)
-        .then((schema) {
-          print('$n => ${schema.validate(n)}');
-          print('$decimals => ${schema.validate(decimals)}');
-          print('$str => ${schema.validate(str)}');
-        });
-
-  This example creates a schema requiring the type be integer. It then
-  tests against three instances with the following results:
-
-    3 => true
-    3.14 => false
-    hi => false
 
 # How To Use Schema Information
 
@@ -168,8 +193,3 @@
   For more detailed image open link:
   <a href="https://raw.github.com/patefacio/json_schema/master/example/from_url/grades_schema.png"
   target="_blank">Grade example schema diagram</a>
-
-# TODOS
-  
-  * Add a remote ref test that does not require files vended from local host
-  * Add support for optional tests: format

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The simplest way to create a schema is to pass JSON data directly to `JsonSchema
 
 After creating any schema, JSON instances can be validated by calling `.validate(instance)` on that schema. By default, instances are expected to be pre-parsed JSON as native dart primitives (`Map`, `List`, `String`, `bool`, `num`, `int`). You can also optionally parse at validation time by passing in a string and setting `parseJson`: `schema.validate('{ "name": "any JSON object"}', parseJson: true)`.
     
-    Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation" examples below.
+  > Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation" examples below.
 
 
 #### Example
 
-A schema can be created with a Map that is either hand-crafted, referneced from a JSON file, or *previously* fetched from the network or file system.
+A schema can be created with a Map that is either hand-crafted, referenced from a JSON file, or *previously* fetched from the network or file system.
 
 ```dart
 import 'package:json_schema/json_schema.dart';
@@ -115,7 +115,7 @@ main() {
 
 ### Asynchronous Creation, Remote HTTP Refs
 
-If you have schemas that have nested $refs that are HTTP URIs that are publically accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well (see next example).
+If you have schemas that have nested $refs that are HTTP URIs that are publicly accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well (see next example).
 
 #### Example
 
@@ -163,7 +163,7 @@ main() async {
 
 ### Asynchronous Creation, From URL or File
 
-You can also create a schema directly from a publically accessible URL, like so:
+You can also create a schema directly from a publicly accessible URL, like so:
 
 #### Example 1 - URL
 
@@ -248,7 +248,7 @@ main() async {
 
 ### Asynchronous Creation, with custom remote $refs:
 
-If you have nested $refs that are either non-HTTP URIs or non-publically-accessible HTTP $refs, you can supply an `RefProviderAsync` to `createSchemaAsync`, and perform any custom logic you need.
+If you have nested $refs that are either non-HTTP URIs or non-publicly-accessible HTTP $refs, you can supply an `RefProviderAsync` to `createSchemaAsync`, and perform any custom logic you need.
 
 #### Example
 
@@ -343,16 +343,9 @@ main() async {
 
 ## How To Use Schema Information
 
-  Schema information can be used for validation; but it can also be a
-  valuable source of information about the structure of data. The
-  Schema class provided here works by fully parsing the schema first,
-  which itself must be valid on all paths within the schema. The only
-  invalid content of a provided schema are _free-form properties_
-  containing schema that are not referenced. Accessors are provided
-  for the meta-data associated with a schema, so tools can do *stuff*
-  with it. 
+  Schema information can be used for validation; but it can also be a valuable source of information about the structure of data. The `JsonSchema` class fully parses the schema first, which itself must be valid on all paths within the schema. Accessors are provided for all specified keywords of the JSON Schema specification associated with a schema, so tools can use it to create rich views of the data, like forms or diagrams.
 
-  One example use is the _schemadot_ program included in the _bin_
+  One example use is the *deprecated* _schemadot_ program included in the _bin_
   folder which takes schema as input and outputs a _Graphviz_ _dot_
   file, providing a picture of the schema. This does not provide all
   information of the schema, and is a work in progress - but it can be

--- a/bin/gensamples.dart
+++ b/bin/gensamples.dart
@@ -37,6 +37,7 @@
 //     THE SOFTWARE.
 
 import 'dart:io';
+
 import 'package:path/path.dart';
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/vm.dart';
@@ -54,6 +55,7 @@ main() {
     final pngOut = join(outPath, '$base.png');
 
     JsonSchema.createSchemaFromUrl(fname).then((schema) {
+      schema.refMap.forEach((key, ref) => print('$key : $ref'));
       new File(dotFilename).writeAsStringSync(createDot(schema));
     }).then((_) {
       Process.run('dot', ['-Tpng', '-o$pngOut', dotFilename]).then((ProcessResult processResult) {

--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -46,10 +46,11 @@
 /// the file, otherwise written to stdout.
 ///
 import 'dart:async';
+import 'package:dart2_constant/convert.dart' as convert2;
 import 'dart:convert' as convert;
 import 'dart:io';
+
 import 'package:args/args.dart';
-import 'package:dart2_constant/convert.dart' as convert2;
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/schema_dot.dart';
 import 'package:logging/logging.dart';

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -50,12 +50,6 @@ main() {
   //////////////////////////////////////////////////////////////////////
   String url = 'http://json-schema.org/draft-04/schema';
   JsonSchema.createSchemaFromUrl(url).then((JsonSchema schema) {
-    // TODO: Figure out the redirect issues here
-    //   if(false) {
-    //     print('''Does schema validate itself?
-    //       ${schema.validate(schema.schemaMap)}''');
-    //   }
-
     final validSchema = {'type': 'integer'};
     print('''Does schema validate valid schema $validSchema?
   ${schema.validate(validSchema)}''');

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -38,6 +38,7 @@
 //     THE SOFTWARE.
 
 import 'package:dart2_constant/convert.dart' as convert;
+
 import 'package:json_schema/json_schema.dart';
 import 'package:logging/logging.dart';
 

--- a/example/readme/asynchronous_creation/from_file.dart
+++ b/example/readme/asynchronous_creation/from_file.dart
@@ -1,3 +1,4 @@
+#!/usr/bin/env dart
 // Copyright 2013-2018 Workiva Inc.
 //
 // Licensed under the Boost Software License (the "License");
@@ -37,32 +38,40 @@
 //     THE SOFTWARE.
 
 import 'dart:io';
-import 'package:path/path.dart';
-import 'package:json_schema/json_schema.dart';
-import 'package:json_schema/vm.dart';
-import 'package:json_schema/schema_dot.dart';
 
-main() {
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
   configureJsonSchemaForVm();
 
-  final sourcePath = join(dirname(dirname(absolute(Platform.script.toFilePath()))), 'dot_samples', 'schemas');
-  final outPath = join(dirname(sourcePath), 'schemaout');
-  new Directory(sourcePath).listSync().forEach((jsonFile) {
-    final fname = jsonFile.path;
-    final base = basenameWithoutExtension(fname);
-    final dotFilename = join(outPath, '$base.dot');
-    final pngOut = join(outPath, '$base.png');
+  // For Browser:
+  // configureJsonSchemaForBrowser();
 
-    JsonSchema.createSchemaFromUrl(fname).then((schema) {
-      new File(dotFilename).writeAsStringSync(createDot(schema));
-    }).then((_) {
-      Process.run('dot', ['-Tpng', '-o$pngOut', dotFilename]).then((ProcessResult processResult) {
-        if (processResult.exitCode == 0) {
-          print('Finished running dot -Tpng -o$pngOut $fname');
-        } else {
-          print('FAILED: running dot -Tpng -o$pngOut $fname');
-        }
-      });
-    });
-  });
+  final file = "example/readme/asynchronous_creation/geo.schema.json";
+
+  final schema = await JsonSchema.createSchemaFromUrl(file);
+
+  // Create some examples to validate against the schema.
+  final workivaAmes = {
+    'latitude': 41.9956731,
+    'longitude': -93.6403663,
+  };
+
+  final nowhereville = {
+    'latitude': -2000,
+    'longitude': 7836,
+  };
+
+  print('$workivaAmes => ${schema.validate(workivaAmes)}'); // true
+  print('$nowhereville => ${schema.validate(nowhereville)}'); // false
+
+  // Exit the process cleanly (VM Only).
+  exit(0);
 }

--- a/example/readme/asynchronous_creation/from_url.dart
+++ b/example/readme/asynchronous_creation/from_url.dart
@@ -1,3 +1,4 @@
+#!/usr/bin/env dart
 // Copyright 2013-2018 Workiva Inc.
 //
 // Licensed under the Boost Software License (the "License");
@@ -37,32 +38,35 @@
 //     THE SOFTWARE.
 
 import 'dart:io';
-import 'package:path/path.dart';
-import 'package:json_schema/json_schema.dart';
-import 'package:json_schema/vm.dart';
-import 'package:json_schema/schema_dot.dart';
 
-main() {
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
   configureJsonSchemaForVm();
 
-  final sourcePath = join(dirname(dirname(absolute(Platform.script.toFilePath()))), 'dot_samples', 'schemas');
-  final outPath = join(dirname(sourcePath), 'schemaout');
-  new Directory(sourcePath).listSync().forEach((jsonFile) {
-    final fname = jsonFile.path;
-    final base = basenameWithoutExtension(fname);
-    final dotFilename = join(outPath, '$base.dot');
-    final pngOut = join(outPath, '$base.png');
+  // For Browser:
+  // configureJsonSchemaForBrowser();
 
-    JsonSchema.createSchemaFromUrl(fname).then((schema) {
-      new File(dotFilename).writeAsStringSync(createDot(schema));
-    }).then((_) {
-      Process.run('dot', ['-Tpng', '-o$pngOut', dotFilename]).then((ProcessResult processResult) {
-        if (processResult.exitCode == 0) {
-          print('Finished running dot -Tpng -o$pngOut $fname');
-        } else {
-          print('FAILED: running dot -Tpng -o$pngOut $fname');
-        }
-      });
-    });
-  });
+  final url = "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json";
+
+  final schema = await JsonSchema.createSchemaFromUrl(url);
+
+  // Create some examples to validate against the schema.
+  final n = 3;
+  final decimals = 3.14;
+  final str = 'hi';
+
+  print('$n => ${schema.validate(n)}'); // true
+  print('$decimals => ${schema.validate(decimals)}'); // false
+  print('$str => ${schema.validate(str)}'); // false
+
+  // Exit the process cleanly (VM Only).
+  exit(0);
 }

--- a/example/readme/asynchronous_creation/geo.schema.json
+++ b/example/readme/asynchronous_creation/geo.schema.json
@@ -1,0 +1,20 @@
+{
+    "id": "https://example.com/geographical-location.schema.json",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Longitude and Latitude Values",
+    "description": "A geographical coordinate.",
+    "required": [ "latitude", "longitude" ],
+    "type": "object",
+    "properties": {
+      "latitude": {
+        "type": "number",
+        "minimum": -90,
+        "maximum": 90
+      },
+      "longitude": {
+        "type": "number",
+        "minimum": -180,
+        "maximum": 180
+      }
+    }
+  }

--- a/example/readme/asynchronous_creation/remote_ref_cache.dart
+++ b/example/readme/asynchronous_creation/remote_ref_cache.dart
@@ -37,9 +37,9 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'dart:io';
 import 'dart:async';
 import 'package:dart2_constant/convert.dart';
+import 'dart:io';
 
 import 'package:json_schema/json_schema.dart';
 

--- a/example/readme/asynchronous_creation/remote_ref_cache.dart
+++ b/example/readme/asynchronous_creation/remote_ref_cache.dart
@@ -1,0 +1,125 @@
+#!/usr/bin/env dart
+// Copyright 2013-2018 Workiva Inc.
+//
+// Licensed under the Boost Software License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.boost.org/LICENSE_1_0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This software or document includes material copied from or derived
+// from JSON-Schema-Test-Suite (https://github.com/json-schema-org/JSON-Schema-Test-Suite),
+// Copyright (c) 2012 Julian Berman, which is licensed under the following terms:
+//
+//     Copyright (c) 2012 Julian Berman
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in
+//     all copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//     THE SOFTWARE.
+
+import 'dart:io';
+import 'dart:async';
+import 'package:dart2_constant/convert.dart';
+
+import 'package:json_schema/json_schema.dart';
+
+// For VM:
+import 'package:json_schema/vm.dart';
+
+// For Browser:
+// import 'package:json_schema/browser.dart';
+
+main() async {
+  // For VM:
+  configureJsonSchemaForVm();
+
+  // For Browser:
+  // configureJsonSchemaForBrowser();
+
+  final referencedSchema = {
+    r"$id": "https://example.com/geographical-location.schema.json",
+    r"$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Longitude and Latitude",
+    "description": "A geographical coordinate on a planet (most commonly Earth).",
+    "required": ["latitude", "longitude"],
+    "type": "object",
+    "properties": {
+      "name": {"type": "string"},
+      "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+      "longitude": {"type": "number", "minimum": -180, "maximum": 180}
+    }
+  };
+
+  final RefProviderAsync refProvider = (String ref) async {
+    final Map references = {
+      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
+    };
+
+    if (references.containsKey(ref)) {
+      // Silly example that adds a 1 second delay.
+      // In practice, you could make any service call here,
+      // parse the results into a schema, and return.
+      await new Future.delayed(new Duration(seconds: 1));
+      return references[ref];
+    }
+
+    // Fall back to default URL $ref behavior
+    return await JsonSchema.createSchemaFromUrl(ref);
+  };
+
+  final schema = await JsonSchema.createSchemaAsync({
+    'type': 'array',
+    'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
+  }, refProvider: refProvider);
+
+  final workivaLocations = [
+    {
+      'name': 'Ames',
+      'latitude': 41.9956731,
+      'longitude': -93.6403663,
+    },
+    {
+      'name': 'Scottsdale',
+      'latitude': 33.4634707,
+      'longitude': -111.9266617,
+    }
+  ];
+
+  final badLocations = [
+    {
+      'name': 'Bad Badlands',
+      'latitude': 181,
+      'longitude': 92,
+    },
+    {
+      'name': 'Nowhereville',
+      'latitude': -2000,
+      'longitude': 7836,
+    }
+  ];
+
+  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+
+  exit(0);
+}

--- a/example/readme/synchronous_creation/local_ref_cache.dart
+++ b/example/readme/synchronous_creation/local_ref_cache.dart
@@ -37,8 +37,9 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'package:json_schema/json_schema.dart';
 import 'package:dart2_constant/convert.dart';
+
+import 'package:json_schema/json_schema.dart';
 
 main() {
   final referencedSchema = {

--- a/example/readme/synchronous_creation/self_contained.dart
+++ b/example/readme/synchronous_creation/self_contained.dart
@@ -1,3 +1,4 @@
+#!/usr/bin/env dart
 // Copyright 2013-2018 Workiva Inc.
 //
 // Licensed under the Boost Software License (the "License");
@@ -36,33 +37,21 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'dart:io';
-import 'package:path/path.dart';
 import 'package:json_schema/json_schema.dart';
-import 'package:json_schema/vm.dart';
-import 'package:json_schema/schema_dot.dart';
 
 main() {
-  configureJsonSchemaForVm();
+  /// Define schema in a Dart [Map] or use a JSON [String].
+  final mustBeIntegerSchemaMap = {"type": "integer"};
 
-  final sourcePath = join(dirname(dirname(absolute(Platform.script.toFilePath()))), 'dot_samples', 'schemas');
-  final outPath = join(dirname(sourcePath), 'schemaout');
-  new Directory(sourcePath).listSync().forEach((jsonFile) {
-    final fname = jsonFile.path;
-    final base = basenameWithoutExtension(fname);
-    final dotFilename = join(outPath, '$base.dot');
-    final pngOut = join(outPath, '$base.png');
+  // Create some examples to validate against the schema.
+  final n = 3;
+  final decimals = 3.14;
+  final str = 'hi';
 
-    JsonSchema.createSchemaFromUrl(fname).then((schema) {
-      new File(dotFilename).writeAsStringSync(createDot(schema));
-    }).then((_) {
-      Process.run('dot', ['-Tpng', '-o$pngOut', dotFilename]).then((ProcessResult processResult) {
-        if (processResult.exitCode == 0) {
-          print('Finished running dot -Tpng -o$pngOut $fname');
-        } else {
-          print('FAILED: running dot -Tpng -o$pngOut $fname');
-        }
-      });
-    });
-  });
+  // Construct the schema from the schema map or JSON string.
+  final schema = JsonSchema.createSchema(mustBeIntegerSchemaMap);
+
+  print('$n => ${schema.validate(n)}'); // true
+  print('$decimals => ${schema.validate(decimals)}'); // false
+  print('$str => ${schema.validate(str)}'); // false
 }

--- a/lib/MIGRATION.md
+++ b/lib/MIGRATION.md
@@ -26,7 +26,7 @@ json_schema 2.0 is here, and is packed with useful updates! We've tried to minim
     - If you were using `createSchema` to evaluate schemas that contained remote references you don't have cached locally, simply switch over to `createSchemaAsync`, which has the same behavior. If you continue to use the synchronous `createSchema`: *errors will be thrown when remote references are encountered*.
     - If you were using `createSchema` to evaluate schemas where all references can be resolved within the root schema, congrats! You can now remove all async behavior around creating schemas. No more async / await :)
     - If you were using `createSchema` to evaluate schema which have remote references, but you can cache all the remote references locally, you can use the optional `RefProvider` to allow sync resolution of those.
-    - A new use case is also available: you can now use custom logic to resolve your own $refs using `AsyncRefProvider` / `createSchemaAsync`.
+    - A new use case is also available: you can now use custom logic to resolve your own $refs using `RefProviderAsync` / `createSchemaAsync`.
 
 - Platforms
   - dart:io Users: A single call to `configureBrowserForVm()` is required before using `createSchemaAsync`.

--- a/lib/MIGRATION.md
+++ b/lib/MIGRATION.md
@@ -23,9 +23,10 @@ json_schema 2.0 is here, and is packed with useful updates! We've tried to minim
 - `JsonShema createSchema`
   - DON'T PANIC, we've changed the signature of the main constructor! We did this in order to allow syncronous evaluation of schemas by default.
   - There are a few paths you can take here:
-    - If you were using `createSchema` to evaluate schemas that contained remote references you don't have cached locally, simply switch over to `createSchemaAsync`, which has the same behavior.
-    - If you were using `createSchema` to evaluate schemas where all references can be resolved within the root schema, congrats, you can now remove all async behavior around creating schemas. No more async / await :)
+    - If you were using `createSchema` to evaluate schemas that contained remote references you don't have cached locally, simply switch over to `createSchemaAsync`, which has the same behavior. If you continue to use the synchronous `createSchema`: *errors will be thrown when remote references are encountered*.
+    - If you were using `createSchema` to evaluate schemas where all references can be resolved within the root schema, congrats! You can now remove all async behavior around creating schemas. No more async / await :)
     - If you were using `createSchema` to evaluate schema which have remote references, but you can cache all the remote references locally, you can use the optional `RefProvider` to allow sync resolution of those.
+    - A new use case is also available: you can now use custom logic to resolve your own $refs using `AsyncRefProvider` / `createSchemaAsync`.
 
 - Platforms
   - dart:io Users: A single call to `configureBrowserForVm()` is required before using `createSchemaAsync`.

--- a/lib/MIGRATION.md
+++ b/lib/MIGRATION.md
@@ -1,0 +1,52 @@
+# json_schema v1.x to v2 Migration Guide
+
+json_schema 2.0 is here, and is packed with useful updates! We've tried to minimize incompatibilities, while taking steps to build for the future. These include:
+
+- json_schema is no longer bound to dart:io!
+  - json_schema can now be used in either the browser or on a server by utilizing `configureJsonSchemaForBrowser()` or `configureBrowserForVm()`. Only necessary if you use async fetch of remote schemas via `createSchemaAsync`.
+- JSON Schema draft6 compatibility
+  - Allowing multiple spec versions (draft4 and draft6)
+- Synchronous evaluation of schemas, by default.
+  - Make fetching referenced schemas possible out-of-band and explicitly, while removing the default behavior to make HTTP calls.
+- Renaming or splitting up certain keyword getters for better type-safety.
+  - i.e. `bool additionalPropertiesBool` and `JsonSchema additionalPropertiesSchema` vs `dynamic addtionalProperties`.
+- Automatic parsing of JSON strings when they are passed to `createSchema`, for more straightforward creation of schemas
+- Optional parsing of JSON strings when they are passed to `validate`.
+- The repo is now maintained by Workiva.
+
+
+## Breaking Changes
+
+- `Schema` --> `JsonSchema`
+  - We've changed the name of the main class, for clarity.
+
+- `JsonShema createSchema`
+  - DON'T PANIC, we've changed the signature of the main constructor! We did this in order to allow syncronous evaluation of schemas by default.
+  - There are a few paths you can take here:
+    - If you were using `createSchema` to evaluate schemas that contained remote references you don't have cached locally, simply switch over to `createSchemaAsync`, which has the same behavior.
+    - If you were using `createSchema` to evaluate schemas where all references can be resolved within the root schema, congrats, you can now remove all async behavior around creating schemas. No more async / await :)
+    - If you were using `createSchema` to evaluate schema which have remote references, but you can cache all the remote references locally, you can use the optional `RefProvider` to allow sync resolution of those.
+
+- Platforms
+ - dart:io Users: A single call to `configureBrowserForVm()` is required if using `createSchemaAsync`.
+  - dart:html Users: A single call to `configureBrowserForBrowser()` is required if using `createSchemaAsync`.
+
+- Removal of Custom Validation Logic
+    - `set uriValidator` and `set emailValidator` have been removed and replaced with spec-supplied logical constraints.
+    - This was removed because it was one-off for these two formats. Look for generic custom format validation in the future.
+
+- `exclusiveMaximum` and `exclusiveMinimum`
+  - changed `bool get exclusiveMinimum` --> `num get exclusiveMinimum` and
+  `bool get exclusiveMaximum` --> `num get exclusiveMaximum`. The old boolean values are available under `bool get hasExclusiveMinimum` and `bool get hasExclusiveMaximum`, while the new values contain the actual value of the min / max. This is consistent with how the spec was changes, see the release notes: https://json-schema.org/draft-06/json-schema-release-notes.html
+
+- `String get ref` --> `Uri get ref`
+  - Since the spec specifies that $refs MUST be a URI, we've given them some additional type safety .(https://tools.ietf.org/html/draft-wright-json-schema-01#section-8).
+
+## Notable Deprecations
+
+- `JsonSchema.refMap`
+  - Note: This information is useful for drawing dependency graphs, etc, but should not be used for general 
+validation or traversal. Use `endPath` to get the absolute `String` path and `resolvePath` to get the `JsonSchema` at any path, instead. This functionality will be removed in 3.0.
+
+- All `schema_dot.dart` exports including `SchemaNode` and `createDot`
+  - Unfortunetly, we don't have the resources to maintain this part of the codebase, as such, it has been untested against the major changes in 2.0, and is marked for future removal. Raise an issue or submit a PR if this was important to you.

--- a/lib/MIGRATION.md
+++ b/lib/MIGRATION.md
@@ -28,8 +28,8 @@ json_schema 2.0 is here, and is packed with useful updates! We've tried to minim
     - If you were using `createSchema` to evaluate schema which have remote references, but you can cache all the remote references locally, you can use the optional `RefProvider` to allow sync resolution of those.
 
 - Platforms
- - dart:io Users: A single call to `configureBrowserForVm()` is required if using `createSchemaAsync`.
-  - dart:html Users: A single call to `configureBrowserForBrowser()` is required if using `createSchemaAsync`.
+  - dart:io Users: A single call to `configureBrowserForVm()` is required before using `createSchemaAsync`.
+  - dart:html Users: A single call to `configureBrowserForBrowser()` is required before using `createSchemaAsync`.
 
 - Removal of Custom Validation Logic
     - `set uriValidator` and `set emailValidator` have been removed and replaced with spec-supplied logical constraints.
@@ -40,7 +40,7 @@ json_schema 2.0 is here, and is packed with useful updates! We've tried to minim
   `bool get exclusiveMaximum` --> `num get exclusiveMaximum`. The old boolean values are available under `bool get hasExclusiveMinimum` and `bool get hasExclusiveMaximum`, while the new values contain the actual value of the min / max. This is consistent with how the spec was changes, see the release notes: https://json-schema.org/draft-06/json-schema-release-notes.html
 
 - `String get ref` --> `Uri get ref`
-  - Since the spec specifies that $refs MUST be a URI, we've given them some additional type safety .(https://tools.ietf.org/html/draft-wright-json-schema-01#section-8).
+  - Since the spec specifies that $refs MUST be a URI, we've given refs some additional type safety.(https://tools.ietf.org/html/draft-wright-json-schema-01#section-8).
 
 ## Notable Deprecations
 

--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -37,7 +37,7 @@
 //     THE SOFTWARE.
 
 export 'package:json_schema/src/json_schema/json_schema.dart' show JsonSchema;
-export 'package:json_schema/src/json_schema/constants.dart' show JsonSchemaVersions;
+export 'package:json_schema/src/json_schema/constants.dart' show SchemaVersion;
 export 'package:json_schema/src/json_schema/schema_type.dart' show SchemaType;
 export 'package:json_schema/src/json_schema/validator.dart' show Validator;
 export 'package:json_schema/src/json_schema/typedefs.dart' show RefProvider, RefProviderAsync;

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -42,6 +42,8 @@ library json_schema.schema_dot;
 import 'package:json_schema/json_schema.dart';
 
 /// Represents one node in the schema diagram
+///
+@Deprecated('This functionality is not maintained, is untested, and may be removed in a future release.')
 class SchemaNode {
   /// Referenced schema this node portrays
   JsonSchema schema;

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -314,6 +314,7 @@ class SchemaNode {
 }
 
 /// Return a dot specification for [schema]
+@Deprecated('This functionality is not maintained, is untested, and may be removed in a future release.')
 String createDot(JsonSchema schema) => '''
 digraph G {
   fontname = "Bitstream Vera Sans"

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -81,8 +81,8 @@ class SchemaNode {
 
   static dynamic schemaType(JsonSchema schema) {
     dynamic result;
-    final schemaTypeList = schema.typeList;
-    if (schemaTypeList == null) {
+    final typeList = schema.typeList;
+    if (typeList == null) {
       if (schema.oneOf.length > 0) {
         result = 'oneOf:${schema.oneOf.map((schema) => schemaType(schema)).toList()}';
       } else if (schema.anyOf.length > 0) {
@@ -101,7 +101,7 @@ class SchemaNode {
         result = '$schema';
       }
     } else {
-      result = schemaTypeList.length == 1 ? schemaTypeList[0] : schemaTypeList;
+      result = typeList.length == 1 ? typeList[0] : typeList;
     }
     if ((result is List) && result.length == 0) result = {};
     if (result == null) result = {};

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -81,7 +81,7 @@ class SchemaNode {
 
   static dynamic schemaType(JsonSchema schema) {
     dynamic result;
-    final schemaTypeList = schema.schemaTypeList;
+    final schemaTypeList = schema.typeList;
     if (schemaTypeList == null) {
       if (schema.oneOf.length > 0) {
         result = 'oneOf:${schema.oneOf.map((schema) => schemaType(schema)).toList()}';

--- a/lib/src/json_schema/browser/platform_functions.dart
+++ b/lib/src/json_schema/browser/platform_functions.dart
@@ -40,10 +40,11 @@ import 'dart:async';
 
 import 'package:w_transport/w_transport.dart';
 
+import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/utils.dart';
 
-Future<JsonSchema> createSchemaFromUrlBrowser(String schemaUrl, {String schemaVersion}) async {
+Future<JsonSchema> createSchemaFromUrlBrowser(String schemaUrl, {SchemaVersion schemaVersion}) async {
   final uriWithFrag = Uri.parse(schemaUrl);
   var uri = uriWithFrag.removeFragment();
   if (schemaUrl.endsWith('#')) {

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -73,23 +73,56 @@ class JsonSchemaValidationRegexes {
   static RegExp jsonPointer = new RegExp(r'^(?:\/(?:[^~/]|~0|~1)*)*$');
 }
 
-class JsonSchemaVersions {
-  static const String draft4 = 'http://json-schema.org/draft-04/schema#';
-  static const String draft6 = 'http://json-schema.org/draft-06/schema#';
+class SchemaVersion implements Comparable<SchemaVersion> {
+  const SchemaVersion._(this.value);
 
-  static List<String> allVersions = const [
-    draft4,
-    draft6,
-  ];
+  static const SchemaVersion draft4 = const SchemaVersion._(0);
+
+  static const SchemaVersion draft6 = const SchemaVersion._(1);
+
+  static List<SchemaVersion> get values => const <SchemaVersion>[draft4, draft6];
+
+  final int value;
+
+  @override
+  int get hashCode => value;
+
+  SchemaVersion copy() => this;
+
+  @override
+  int compareTo(SchemaVersion other) => value.compareTo(other.value);
+
+  @override
+  String toString() {
+    switch (this) {
+      case draft4:
+        return 'http://json-schema.org/draft-04/schema#';
+      case draft6:
+        return 'http://json-schema.org/draft-06/schema#';
+    }
+    return null;
+  }
+
+  static SchemaVersion fromString(String s) {
+    if (s == null) return null;
+    switch (s) {
+      case 'http://json-schema.org/draft-04/schema#':
+        return draft4;
+      case 'http://json-schema.org/draft-06/schema#':
+        return draft6;
+      default:
+        return null;
+    }
+  }
 }
 
-Map getJsonSchemaDefinitionByRef(String ref) {
+String getJsonSchemaDefinitionByRef(String ref) {
   final mapping = {
-    JsonSchemaVersions.draft4: JsonSchemaDefinitions.draft4,
-    JsonSchemaVersions.draft6: JsonSchemaDefinitions.draft6,
+    SchemaVersion.draft4.toString(): JsonSchemaDefinitions.draft4,
+    SchemaVersion.draft6.toString(): JsonSchemaDefinitions.draft6,
   };
 
-  if (JsonSchemaVersions.allVersions.contains(ref)) {
+  if (SchemaVersion.values.map((value) => value.toString()).contains(ref)) {
     return mapping[ref];
   }
 
@@ -97,7 +130,7 @@ Map getJsonSchemaDefinitionByRef(String ref) {
 }
 
 class JsonSchemaDefinitions {
-  static Map draft4 = json.decode(r'''
+  static String draft4 = r'''
     {
     "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -247,9 +280,9 @@ class JsonSchemaDefinitions {
     },
     "default": {}
 }
-    ''');
+    ''';
 
-  static Map draft6 = json.decode(r'''
+  static String draft6 = r'''
     {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://json-schema.org/draft-06/schema#",
@@ -404,5 +437,5 @@ class JsonSchemaDefinitions {
     },
     "default": {}
 }
-    ''');
+    ''';
 }

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -36,8 +36,6 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'package:dart2_constant/convert.dart';
-
 class JsonSchemaValidationRegexes {
   static RegExp email = new RegExp(r'^[_A-Za-z0-9-\+]+(\.[_A-Za-z0-9-]+)*'
       r'@'

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -728,6 +728,9 @@ class JsonSchema {
   /// JSON of the [JsonSchema] as a [bool]. Only this value or [_schemaMap] should be set, not both.
   bool get schemaBool => _schemaBool;
 
+  /// JSON string represenatation of the schema.
+  String toJson() => json.encode(_schemaMap ?? _schemaBool);
+
   /// JSON Schema version used.
   ///
   /// Note: Only one version can be used for a nested [JsonScehema] object.

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -522,7 +522,7 @@ class JsonSchema {
   String _title;
 
   /// List of allowable types for the [JsonSchema].
-  List<SchemaType> _schemaTypeList;
+  List<SchemaType> _typeList;
 
   // --------------------------------------------------------------------------
   // Schema List Item Related Fields
@@ -873,7 +873,10 @@ class JsonSchema {
   String get title => _title;
 
   /// List of allowable types for the [JsonSchema].
-  List<SchemaType> get schemaTypeList => _schemaTypeList;
+  List<SchemaType> get typeList => _typeList;
+
+  /// Single allowable type for the [JsonSchema].
+  SchemaType get type => _typeList.length == 1 ? _typeList.single : null;
 
   // --------------------------------------------------------------------------
   // Schema List Item Related Getters
@@ -1232,7 +1235,7 @@ class JsonSchema {
   _setTitle(dynamic value) => _title = TypeValidators.string('title', value);
 
   /// Validate, calculate and set the value of the 'type' JSON Schema prop.
-  _setType(dynamic value) => _schemaTypeList = TypeValidators.schemaTypeList('type', value);
+  _setType(dynamic value) => _typeList = TypeValidators.typeList('type', value);
 
   // --------------------------------------------------------------------------
   // Schema List Item Related Property Setters

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -772,32 +772,32 @@ class JsonSchema {
   }
 
   /// Whether or not const is set, we need this since const can be null and valid.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
   bool get hasConst => _hasConst;
 
   /// Const value of the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
   dynamic get constValue => _constValue;
 
   /// Default value of the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
   dynamic get defaultValue => _defaultValue;
 
   /// Included [JsonSchema] definitions.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.1
   Map<String, JsonSchema> get definitions => _definitions;
 
   /// Description of the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
   String get description => _description;
 
   /// Possible values of the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
   List get enumValues => _enumValues;
 
@@ -855,27 +855,27 @@ class JsonSchema {
   }
 
   /// Maximum value of the [JsonSchema] value.
-  /// 
+  ///
   /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.2
   num get maximum => _maximum;
 
   /// Minimum value of the [JsonSchema] value.
-  /// 
+  ///
   /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.4
   num get minimum => _minimum;
 
   /// Maximum length of the [JsonSchema] value.
-  /// 
+  ///
   /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.6
   int get maxLength => _maxLength;
 
   /// Minimum length of the [JsonSchema] value.
-  /// 
+  ///
   /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.7
   int get minLength => _minLength;
 
   /// The number which the value of the [JsonSchema] must be a multiple of.
-  /// 
+  ///
   /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.1
   num get multipleOf => _multipleOf;
 
@@ -883,27 +883,27 @@ class JsonSchema {
   String get path => _path;
 
   /// The regular expression the [JsonSchema] value must conform to.
-  /// 
-  /// Refernce: 
+  ///
+  /// Refernce:
   RegExp get pattern => _pattern;
 
   /// A [List<JsonSchema>] which the value must conform to all of.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.26
   List<JsonSchema> get allOf => _allOf;
 
   /// A [List<JsonSchema>] which the value must conform to at least one of.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.27
   List<JsonSchema> get anyOf => _anyOf;
 
   /// A [List<JsonSchema>] which the value must conform to at least one of.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
   List<JsonSchema> get oneOf => _oneOf;
 
   /// A [JsonSchema] which the value must NOT be.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.29
   JsonSchema get notSchema => _notSchema;
 
@@ -911,17 +911,17 @@ class JsonSchema {
   Uri get ref => _ref;
 
   /// Title of the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
   String get title => _title;
 
   /// List of allowable types for the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
   List<SchemaType> get typeList => _typeList;
 
   /// Single allowable type for the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
   SchemaType get type => _typeList.length == 1 ? _typeList.single : null;
 
@@ -930,17 +930,17 @@ class JsonSchema {
   // --------------------------------------------------------------------------
 
   /// Single [JsonSchema] sub items of this [JsonSchema] must conform to.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
   JsonSchema get items => _items;
 
   /// Ordered list of [JsonSchema] which the value of the same index must conform to.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
   List<JsonSchema> get itemsList => _itemsList;
 
   /// Whether additional items are allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10
   bool get additionalItemsBool => _additionalItemsBool;
 
@@ -950,22 +950,26 @@ class JsonSchema {
   JsonSchema get additionalItemsSchema => _additionalItemsSchema;
 
   /// List of example instances for the [JsonSchema].
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.4
-  List get examples => defaultValue != null ? ([]..addAll(_examples)..add(defaultValue)) : _examples;
+  List get examples => defaultValue != null
+      ? ([]
+        ..addAll(_examples)
+        ..add(defaultValue))
+      : _examples;
 
   /// The maximum number of items allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.11
   int get maxItems => _maxItems;
 
   /// The minimum number of items allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.12
   int get minItems => _minItems;
 
   /// Whether the items in the list must be unique.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13
   bool get uniqueItems => _uniqueItems;
 
@@ -974,54 +978,54 @@ class JsonSchema {
   // --------------------------------------------------------------------------
 
   /// Map of [JsonSchema]s for properties, by [String] key.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.18
   Map<String, JsonSchema> get properties => _properties;
 
   /// [JsonSchema] that property names must conform to.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.22
   JsonSchema get propertyNamesSchema => _propertyNamesSchema;
 
   /// Whether additional properties, other than those specified, are allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
   bool get additionalPropertiesBool => _additionalProperties;
 
   /// [JsonSchema] that additional properties must conform to.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
   JsonSchema get additionalPropertiesSchema => _additionalPropertiesSchema;
 
   /// [JsonSchema] definition that at least one item must match to be valid.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.14
   JsonSchema get contains => _contains;
 
   /// The maximum number of properties allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.15
   int get maxProperties => _maxProperties;
 
   /// The minimum number of properties allowed.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.16
   int get minProperties => _minProperties;
 
   /// Map of [JsonSchema]s for properties, based on [RegExp]s keys.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.19
   Map<RegExp, JsonSchema> get patternProperties => _patternProperties;
 
   /// Map of property dependencies by property name.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.21
   Map<String, List<String>> get propertyDependencies => _propertyDependencies;
 
   /// Map of sub-properties' and references' [JsonSchema]s by path.
-  /// 
-  /// Note: This is useful for drawing dependency graphs, etc, but should not be used for general 
-  /// validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath] 
+  ///
+  /// Note: This is useful for drawing dependency graphs, etc, but should not be used for general
+  /// validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath]
   /// to get the [JsonSchema] at any path, instead.
   @Deprecated('''
 Note: This information is useful for drawing dependency graphs, etc, but should not be used for general 
@@ -1033,12 +1037,12 @@ This functionality will be removed in 3.0.
   Map<String, JsonSchema> get refMap => _refMap;
 
   /// Properties that must be inclueded for the [JsonSchema] to be valid.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.17
   List<String> get requiredProperties => _requiredProperties;
 
   /// Map of schema dependencies by property name.
-  /// 
+  ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.21
   Map<String, JsonSchema> get schemaDependencies => _schemaDependencies;
 
@@ -1072,7 +1076,8 @@ This functionality will be removed in 3.0.
   bool propertyRequired(String property) => _requiredProperties != null && _requiredProperties.contains(property);
 
   /// Validate [instance] against this schema
-  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false}) => new Validator(this).validate(instance, reportMultipleErrors: reportMultipleErrors, parseJson: parseJson);
+  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false}) =>
+      new Validator(this).validate(instance, reportMultipleErrors: reportMultipleErrors, parseJson: parseJson);
 
   // --------------------------------------------------------------------------
   // JSON Schema Internal Operations

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -467,6 +467,9 @@ class JsonSchema {
   /// Possible values of the [JsonSchema].
   List _enumValues = [];
 
+  /// Example values for the given schema.
+  List _examples = [];
+
   /// Whether the maximum of the [JsonSchema] is exclusive.
   bool _exclusiveMaximum;
 
@@ -685,6 +688,7 @@ class JsonSchema {
       // Added in draft6
       'const': (JsonSchema s, dynamic v) => s._setConst(v),
       'contains': (JsonSchema s, dynamic v) => s._setContains(v),
+      'examples': (JsonSchema s, dynamic v) => s._setExamples(v),
       'propertyNames': (JsonSchema s, dynamic v) => s._setPropertyNames(v),
       // changed (imcompatible) in draft6
       'exclusiveMaximum': (JsonSchema s, dynamic v) => s._setExclusiveMaximumV6(v),
@@ -1269,6 +1273,9 @@ class JsonSchema {
 
   /// Validate, calculate and set the value of the 'contains' JSON Schema prop.
   _setContains(dynamic value) => _makeSchema('$_path/contains', value, (rhs) => _contains = rhs);
+
+  /// Validate, calculate and set the value of the 'examples' JSOM Schema prop.
+  _setExamples(dynamic value) => _examples = TypeValidators.list('examples', value);
 
   /// Validate, calculate and set the value of the 'maxItems' JSON Schema prop.
   _setMaxItems(dynamic value) => _maxItems = TypeValidators.nonNegativeInt('maxItems', value);

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -114,6 +114,7 @@ class JsonSchema {
     dynamic data = schema;
 
     /// JSON Schemas must be [bool]s or [Map]s, so if we encounter a [String], we're looking at encoded JSON.
+    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1
     if (schema is String) {
       try {
         data = json.decode(schema);
@@ -155,6 +156,7 @@ class JsonSchema {
     dynamic data = schema;
 
     /// JSON Schemas must be [bool]s or [Map]s, so if we encounter a [String], we're looking at encoded JSON.
+    /// https://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1
     if (schema is String) {
       try {
         data = json.decode(schema);
@@ -540,7 +542,7 @@ class JsonSchema {
   /// Whether additional items are allowed.
   bool _additionalItemsBool;
 
-  /// [JsonSchema] additionalItmes should conform to.
+  /// [JsonSchema] additionalItems should conform to.
   JsonSchema _additionalItemsSchema;
 
   /// [JsonSchema] definition that at least one item must match to be valid.
@@ -770,21 +772,33 @@ class JsonSchema {
   }
 
   /// Whether or not const is set, we need this since const can be null and valid.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
   bool get hasConst => _hasConst;
 
   /// Const value of the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
   dynamic get constValue => _constValue;
 
   /// Default value of the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
   dynamic get defaultValue => _defaultValue;
 
   /// Included [JsonSchema] definitions.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.1
   Map<String, JsonSchema> get definitions => _definitions;
 
   /// Description of the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
   String get description => _description;
 
   /// Possible values of the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
   List get enumValues => _enumValues;
 
   /// The value of the exclusiveMaximum for the [JsonSchema], if any exists.
@@ -841,48 +855,74 @@ class JsonSchema {
   }
 
   /// Maximum value of the [JsonSchema] value.
+  /// 
+  /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.2
   num get maximum => _maximum;
 
   /// Minimum value of the [JsonSchema] value.
+  /// 
+  /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.4
   num get minimum => _minimum;
 
   /// Maximum length of the [JsonSchema] value.
+  /// 
+  /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.6
   int get maxLength => _maxLength;
 
   /// Minimum length of the [JsonSchema] value.
+  /// 
+  /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.7
   int get minLength => _minLength;
 
   /// The number which the value of the [JsonSchema] must be a multiple of.
+  /// 
+  /// Reference: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.1
   num get multipleOf => _multipleOf;
 
   /// The path of the [JsonSchema] within the root [JsonSchema].
   String get path => _path;
 
   /// The regular expression the [JsonSchema] value must conform to.
+  /// 
+  /// Refernce: 
   RegExp get pattern => _pattern;
 
   /// A [List<JsonSchema>] which the value must conform to all of.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.26
   List<JsonSchema> get allOf => _allOf;
 
   /// A [List<JsonSchema>] which the value must conform to at least one of.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.27
   List<JsonSchema> get anyOf => _anyOf;
 
   /// A [List<JsonSchema>] which the value must conform to at least one of.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
   List<JsonSchema> get oneOf => _oneOf;
 
   /// A [JsonSchema] which the value must NOT be.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.29
   JsonSchema get notSchema => _notSchema;
 
   /// Ref to the URI of the [JsonSchema].
   Uri get ref => _ref;
 
   /// Title of the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
   String get title => _title;
 
   /// List of allowable types for the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
   List<SchemaType> get typeList => _typeList;
 
   /// Single allowable type for the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
   SchemaType get type => _typeList.length == 1 ? _typeList.single : null;
 
   // --------------------------------------------------------------------------
@@ -890,24 +930,43 @@ class JsonSchema {
   // --------------------------------------------------------------------------
 
   /// Single [JsonSchema] sub items of this [JsonSchema] must conform to.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
   JsonSchema get items => _items;
 
   /// Ordered list of [JsonSchema] which the value of the same index must conform to.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
   List<JsonSchema> get itemsList => _itemsList;
 
   /// Whether additional items are allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10
   bool get additionalItemsBool => _additionalItemsBool;
 
   /// JsonSchema additional items should conform to.
+  ///
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10
   JsonSchema get additionalItemsSchema => _additionalItemsSchema;
 
+  /// List of example instances for the [JsonSchema].
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.4
+  List get examples => defaultValue != null ? ([]..addAll(_examples)..add(defaultValue)) : _examples;
+
   /// The maximum number of items allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.11
   int get maxItems => _maxItems;
 
   /// The minimum number of items allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.12
   int get minItems => _minItems;
 
   /// Whether the items in the list must be unique.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13
   bool get uniqueItems => _uniqueItems;
 
   // --------------------------------------------------------------------------
@@ -915,30 +974,48 @@ class JsonSchema {
   // --------------------------------------------------------------------------
 
   /// Map of [JsonSchema]s for properties, by [String] key.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.18
   Map<String, JsonSchema> get properties => _properties;
 
   /// [JsonSchema] that property names must conform to.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.22
   JsonSchema get propertyNamesSchema => _propertyNamesSchema;
 
   /// Whether additional properties, other than those specified, are allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
   bool get additionalPropertiesBool => _additionalProperties;
 
   /// [JsonSchema] that additional properties must conform to.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
   JsonSchema get additionalPropertiesSchema => _additionalPropertiesSchema;
 
   /// [JsonSchema] definition that at least one item must match to be valid.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.14
   JsonSchema get contains => _contains;
 
   /// The maximum number of properties allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.15
   int get maxProperties => _maxProperties;
 
   /// The minimum number of properties allowed.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.16
   int get minProperties => _minProperties;
 
   /// Map of [JsonSchema]s for properties, based on [RegExp]s keys.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.19
   Map<RegExp, JsonSchema> get patternProperties => _patternProperties;
 
   /// Map of property dependencies by property name.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.21
   Map<String, List<String>> get propertyDependencies => _propertyDependencies;
 
   /// Map of sub-properties' and references' [JsonSchema]s by path.
@@ -956,16 +1033,20 @@ This functionality will be removed in 3.0.
   Map<String, JsonSchema> get refMap => _refMap;
 
   /// Properties that must be inclueded for the [JsonSchema] to be valid.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.17
   List<String> get requiredProperties => _requiredProperties;
 
   /// Map of schema dependencies by property name.
+  /// 
+  /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.21
   Map<String, JsonSchema> get schemaDependencies => _schemaDependencies;
 
   // --------------------------------------------------------------------------
   // Convenience Methods
   // --------------------------------------------------------------------------
 
-  /// Given path, follow all references to an end path pointing to [JsonSchema].
+  /// Given a path within the schema, follow all references to an end path pointing to a [JsonSchema].
   String endPath(String path) {
     _pathsEncountered.clear();
     return _endPath(path);

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -969,9 +969,6 @@ class JsonSchema {
     }
   }
 
-  /// Returns paths of all paths
-  Set get paths => new Set.from(_schemaRefs.keys)..addAll(_refMap.keys);
-
   /// Whether a given property is required for the [JsonSchema] instance to be valid.
   bool propertyRequired(String property) => _requiredProperties != null && _requiredProperties.contains(property);
 

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -928,16 +928,16 @@ class JsonSchema {
   /// Map of [JsonSchema]s for properties, based on [RegExp]s keys.
   Map<RegExp, JsonSchema> get patternProperties => _patternProperties;
 
-  /// TODO: write an informative comment for this.
+  /// Map of property dependencies by property name.
   Map<String, List<String>> get propertyDependencies => _propertyDependencies;
 
-  /// Map of sub-properties' [JsonSchema] by path. TODO: this might be inaccurate.
+  /// Map of sub-properties' [JsonSchema] by path.
   Map<String, JsonSchema> get refMap => _refMap;
 
   /// Properties that must be inclueded for the [JsonSchema] to be valid.
   List<String> get requiredProperties => _requiredProperties;
 
-  /// TODO: write an informative comment for this.
+  /// Map of schema dependencies by property name.
   Map<String, JsonSchema> get schemaDependencies => _schemaDependencies;
 
   // --------------------------------------------------------------------------

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -973,7 +973,7 @@ class JsonSchema {
   bool propertyRequired(String property) => _requiredProperties != null && _requiredProperties.contains(property);
 
   /// Validate [instance] against this schema
-  bool validate(dynamic instance) => new Validator(this).validate(instance);
+  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false}) => new Validator(this).validate(instance, reportMultipleErrors: reportMultipleErrors, parseJson: parseJson);
 
   // --------------------------------------------------------------------------
   // JSON Schema Internal Operations

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -534,8 +534,11 @@ class JsonSchema {
   /// List of [JsonSchema] used to validate items of this schema.
   List<JsonSchema> _itemsList;
 
-  /// Whether additional items are allowed or the [JsonSchema] they should conform to.
-  /* union bool | Map */ dynamic _additionalItems;
+  /// Whether additional items are allowed.
+  bool _additionalItemsBool;
+
+  /// [JsonSchema] additionalItmes should conform to.
+  JsonSchema _additionalItemsSchema;
 
   /// [JsonSchema] definition that at least one item must match to be valid.
   JsonSchema _contains;
@@ -882,8 +885,11 @@ class JsonSchema {
   /// Ordered list of [JsonSchema] which the value of the same index must conform to.
   List<JsonSchema> get itemsList => _itemsList;
 
-  /// Whether additional items are allowed or the [JsonSchema] they should conform to.
-  /* union bool | Map */ dynamic get additionalItems => _additionalItems;
+  /// Whether additional items are allowed.
+  bool get additionalItemsBool => _additionalItemsBool;
+
+  /// JsonSchema additional items should conform to.
+  JsonSchema get additionalItemsSchema => _additionalItemsSchema;
 
   /// The maximum number of items allowed.
   int get maxItems => _maxItems;
@@ -1250,9 +1256,9 @@ class JsonSchema {
   /// Validate, calculate and set the value of the 'additionalItems' JSON Schema prop.
   _setAdditionalItems(dynamic value) {
     if (value is bool) {
-      _additionalItems = value;
+      _additionalItemsBool = value;
     } else if (value is Map) {
-      _makeSchema('$_path/additionalItems', value, (rhs) => _additionalItems = rhs);
+      _makeSchema('$_path/additionalItems', value, (rhs) => _additionalItemsSchema = rhs);
     } else {
       throw FormatExceptions.error('additionalItems must be boolean or object: $value');
     }

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1371,7 +1371,7 @@ This functionality will be removed in 3.0.
   /// Validate, calculate and set the value of the 'contains' JSON Schema prop.
   _setContains(dynamic value) => _makeSchema('$_path/contains', value, (rhs) => _contains = rhs);
 
-  /// Validate, calculate and set the value of the 'examples' JSOM Schema prop.
+  /// Validate, calculate and set the value of the 'examples' JSON Schema prop.
   _setExamples(dynamic value) => _examples = TypeValidators.list('examples', value);
 
   /// Validate, calculate and set the value of the 'maxItems' JSON Schema prop.

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -914,7 +914,7 @@ class JsonSchema {
   JsonSchema get propertyNamesSchema => _propertyNamesSchema;
 
   /// Whether additional properties, other than those specified, are allowed.
-  bool get additionalProperties => _additionalProperties;
+  bool get additionalPropertiesBool => _additionalProperties;
 
   /// [JsonSchema] that additional properties must conform to.
   JsonSchema get additionalPropertiesSchema => _additionalPropertiesSchema;

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -941,7 +941,18 @@ class JsonSchema {
   /// Map of property dependencies by property name.
   Map<String, List<String>> get propertyDependencies => _propertyDependencies;
 
-  /// Map of sub-properties' [JsonSchema] by path.
+  /// Map of sub-properties' and references' [JsonSchema]s by path.
+  /// 
+  /// Note: This is useful for drawing dependency graphs, etc, but should not be used for general 
+  /// validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath] 
+  /// to get the [JsonSchema] at any path, instead.
+  @Deprecated('''
+Note: This information is useful for drawing dependency graphs, etc, but should not be used for general 
+validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath] 
+to get the [JsonSchema] at any path, instead.
+
+This functionality will be removed in 3.0.
+  ''')
   Map<String, JsonSchema> get refMap => _refMap;
 
   /// Properties that must be inclueded for the [JsonSchema] to be valid.

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -106,7 +106,7 @@ class JsonSchema {
   /// If you want to create a [JsonSchema] synchronously, use [createSchema]. Note that for
   /// [createSchema] remote reference fetching is not supported.
   ///
-  /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec), 
+  /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec),
   /// or alternatively, a [String] may be passed in and JSON decoding will be handled automatically.
   static Future<JsonSchema> createSchemaAsync(dynamic schema,
       {SchemaVersion schemaVersion, Uri fetchedFromUri, RefProviderAsync refProvider}) {
@@ -147,7 +147,7 @@ class JsonSchema {
   /// This method is synchronous, and doesn't support fetching of remote references, properties, and sub-properties of the
   /// schema. If you need remote reference support use [createSchemaAsync].
   ///
-  /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec), 
+  /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec),
   /// or alternatively, a [String] may be passed in and JSON decoding will be handled automatically.
   static JsonSchema createSchema(dynamic schema,
       {SchemaVersion schemaVersion, Uri fetchedFromUri, RefProvider refProvider}) {
@@ -1240,8 +1240,8 @@ class JsonSchema {
 
   /// Validate, calculate and set items of the 'pattern' JSON Schema prop that are also [JsonSchema]s.
   _setItems(dynamic value) {
-      _makeSchema('$_path/items', value, (rhs) => _items = rhs);
     if (value is Map || value is bool && schemaVersion == SchemaVersion.draft6) {
+      _makeSchema('$_path/items', value, (rhs) => _items = rhs);
     } else if (value is List) {
       int index = 0;
       _itemsList = new List(value.length);

--- a/lib/src/json_schema/schema_type.dart
+++ b/lib/src/json_schema/schema_type.dart
@@ -39,21 +39,21 @@
 class SchemaType implements Comparable<SchemaType> {
   const SchemaType._(this.value);
 
-  static const SchemaType ARRAY = const SchemaType._(0);
+  static const SchemaType array = const SchemaType._(0);
 
-  static const SchemaType BOOLEAN = const SchemaType._(1);
+  static const SchemaType boolean = const SchemaType._(1);
 
-  static const SchemaType INTEGER = const SchemaType._(2);
+  static const SchemaType integer = const SchemaType._(2);
 
-  static const SchemaType NUMBER = const SchemaType._(3);
+  static const SchemaType number = const SchemaType._(3);
 
-  static const SchemaType NULL = const SchemaType._(4);
+  static const SchemaType nullValue = const SchemaType._(4);
 
-  static const SchemaType OBJECT = const SchemaType._(5);
+  static const SchemaType object = const SchemaType._(5);
 
-  static const SchemaType STRING = const SchemaType._(6);
+  static const SchemaType string = const SchemaType._(6);
 
-  static List<SchemaType> get values => const <SchemaType>[ARRAY, BOOLEAN, INTEGER, NUMBER, NULL, OBJECT, STRING];
+  static List<SchemaType> get values => const <SchemaType>[array, boolean, integer, number, nullValue, object, string];
 
   final int value;
 
@@ -68,19 +68,19 @@ class SchemaType implements Comparable<SchemaType> {
   @override
   String toString() {
     switch (this) {
-      case ARRAY:
+      case array:
         return 'array';
-      case BOOLEAN:
+      case boolean:
         return 'boolean';
-      case INTEGER:
+      case integer:
         return 'integer';
-      case NUMBER:
+      case number:
         return 'number';
-      case NULL:
+      case nullValue:
         return 'null';
-      case OBJECT:
+      case object:
         return 'object';
-      case STRING:
+      case string:
         return 'string';
     }
     return null;
@@ -90,19 +90,19 @@ class SchemaType implements Comparable<SchemaType> {
     if (s == null) return null;
     switch (s) {
       case 'array':
-        return ARRAY;
+        return array;
       case 'boolean':
-        return BOOLEAN;
+        return boolean;
       case 'integer':
-        return INTEGER;
+        return integer;
       case 'number':
-        return NUMBER;
+        return number;
       case 'null':
-        return NULL;
+        return nullValue;
       case 'object':
-        return OBJECT;
+        return object;
       case 'string':
-        return STRING;
+        return string;
       default:
         return null;
     }

--- a/lib/src/json_schema/type_validators.dart
+++ b/lib/src/json_schema/type_validators.dart
@@ -84,10 +84,11 @@ class TypeValidators {
     throw FormatExceptions.object(key, value);
   }
 
-  static String jsonSchemaVersion4Or6(String key, dynamic value) {
+  static SchemaVersion jsonSchemaVersion4Or6(String key, dynamic value) {
     string(key, value);
-    if (JsonSchemaVersions.allVersions.contains(value)) {
-      return value;
+    final schemaVersion = SchemaVersion.fromString(value);
+    if (schemaVersion != null) {
+      return schemaVersion;
     }
     throw FormatExceptions.error('Only draft 4 and draft 6 schemas supported');
   }

--- a/lib/src/json_schema/type_validators.dart
+++ b/lib/src/json_schema/type_validators.dart
@@ -40,7 +40,7 @@ class TypeValidators {
     throw FormatExceptions.error('$key must be a non-empty string: $value');
   }
 
-  static List<SchemaType> schemaTypeList(String key, dynamic value) {
+  static List<SchemaType> typeList(String key, dynamic value) {
     var typeList;
     if (value is String) {
       typeList = [SchemaType.fromString(value)];

--- a/lib/src/json_schema/typedefs.dart
+++ b/lib/src/json_schema/typedefs.dart
@@ -37,8 +37,10 @@
 //     THE SOFTWARE.
 
 import 'dart:async';
+
+import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 
-typedef Future<JsonSchema> CreateJsonSchemaFromUrl(String schemaUrl, {String schemaVersion});
+typedef Future<JsonSchema> CreateJsonSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion});
 typedef JsonSchema RefProvider(String ref);
 typedef Future<JsonSchema> RefProviderAsync(String ref);

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -36,8 +36,8 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'dart:math';
 import 'package:dart2_constant/convert.dart';
+import 'dart:math';
 
 import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -135,7 +135,7 @@ class Validator {
   }
 
   void _typeValidation(JsonSchema schema, dynamic instance) {
-    final typeList = schema.schemaTypeList;
+    final typeList = schema.typeList;
     if (typeList != null && typeList.length > 0) {
       if (!typeList.any((type) => _typeMatch(type, schema, instance))) {
         _err('${schema.path}: type: wanted ${typeList} got $instance');
@@ -183,7 +183,6 @@ class Validator {
       instance.forEach((item) => _validate(singleSchema, item));
     } else {
       final items = schema.itemsList;
-      final additionalItems = schema.additionalItems;
 
       if (items != null) {
         final expected = items.length;

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -192,12 +192,12 @@ class Validator {
           assert(items[i] != null);
           _validate(items[i], instance[i]);
         }
-        if (additionalItems is JsonSchema) {
+        if (schema.additionalItemsSchema != null) {
           for (int i = end; i < actual; i++) {
-            _validate(additionalItems, instance[i]);
+            _validate(schema.additionalItemsSchema, instance[i]);
           }
-        } else if (additionalItems is bool) {
-          if (!additionalItems && actual > end) {
+        } else if (schema.additionalItemsBool != null) {
+          if (!schema.additionalItemsBool && actual > end) {
             _err('${schema.path}: additionalItems false');
           }
         }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -80,8 +80,8 @@ class Validator {
         return instance is String;
       case SchemaType.INTEGER:
         return instance is int ||
-            (schema.schemaVersion == JsonSchemaVersions.draft6 && instance is num && instance.remainder(1) == 0);
       case SchemaType.NUMBER:
+            (schema.schemaVersion == SchemaVersion.draft6 && instance is num && instance.remainder(1) == 0);
         return instance is num;
       case SchemaType.ARRAY:
         return instance is List;
@@ -289,7 +289,7 @@ class Validator {
         break;
       case 'uri-reference':
         {
-          if (schema.schemaVersion != JsonSchemaVersions.draft6)
+          if (schema.schemaVersion != SchemaVersion.draft6)
             _err('${schema.format} not supported as format before draft6');
           final isValid = defaultValidators.uriReferenceValidator ?? (_) => false;
 
@@ -300,7 +300,7 @@ class Validator {
         break;
       case 'uri-template':
         {
-          if (schema.schemaVersion != JsonSchemaVersions.draft6)
+          if (schema.schemaVersion != SchemaVersion.draft6)
             _err('${schema.format} not supported as format before draft6');
           final isValid = defaultValidators.uriTemplateValidator ?? (_) => false;
 
@@ -341,7 +341,7 @@ class Validator {
         break;
       case 'json-pointer':
         {
-          if (schema.schemaVersion != JsonSchemaVersions.draft6)
+          if (schema.schemaVersion != SchemaVersion.draft6)
             _err('${schema.format} not supported as format before draft6');
           if (JsonSchemaValidationRegexes.jsonPointer.firstMatch(instance) == null) {
             _err('json-pointer" format not accepted $instance');

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -74,20 +74,20 @@ class Validator {
 
   static bool _typeMatch(SchemaType type, JsonSchema schema, dynamic instance) {
     switch (type) {
-      case SchemaType.OBJECT:
+      case SchemaType.object:
         return instance is Map;
-      case SchemaType.STRING:
+      case SchemaType.string:
         return instance is String;
-      case SchemaType.INTEGER:
+      case SchemaType.integer:
         return instance is int ||
-      case SchemaType.NUMBER:
             (schema.schemaVersion == SchemaVersion.draft6 && instance is num && instance.remainder(1) == 0);
+      case SchemaType.number:
         return instance is num;
-      case SchemaType.ARRAY:
+      case SchemaType.array:
         return instance is List;
-      case SchemaType.BOOLEAN:
+      case SchemaType.boolean:
         return instance is bool;
-      case SchemaType.NULL:
+      case SchemaType.nullValue:
         return instance == null;
     }
     return false;

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -355,7 +355,7 @@ class Validator {
   }
 
   void _objectPropertyValidation(JsonSchema schema, Map instance) {
-    final propMustValidate = schema.additionalProperties != null && !schema.additionalProperties;
+    final propMustValidate = schema.additionalPropertiesBool != null && !schema.additionalPropertiesBool;
 
     instance.forEach((k, v) {
       // Validate property names against the provided schema, if any.

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -37,6 +37,7 @@
 //     THE SOFTWARE.
 
 import 'dart:math';
+import 'package:dart2_constant/convert.dart';
 
 import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
@@ -51,14 +52,23 @@ class Validator {
   List<String> get errors => _errors;
 
   /// Validate the [instance] against the this validator's schema
-  bool validate(dynamic instance, [bool reportMultipleErrors = false]) {
+  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false}) {
     // _logger.info('Validating ${instance.runtimeType}:$instance on ${_rootSchema}'); TODO: re-add logger
+
+    dynamic data = instance;
+    if (parseJson && instance is String) {
+      try {
+        data = json.decode(instance);
+      } catch (e) {
+        throw new ArgumentError('JSON instance provided to validate is not valid JSON.');
+      }
+    }
 
     _reportMultipleErrors = reportMultipleErrors;
     _errors = [];
     if (!_reportMultipleErrors) {
       try {
-        _validate(_rootSchema, instance);
+        _validate(_rootSchema, data);
         return true;
       } on FormatException {
         return false;
@@ -68,7 +78,7 @@ class Validator {
       }
     }
 
-    _validate(_rootSchema, instance);
+    _validate(_rootSchema, data);
     return _errors.length == 0;
   }
 

--- a/lib/src/json_schema/vm/platform_functions.dart
+++ b/lib/src/json_schema/vm/platform_functions.dart
@@ -41,10 +41,12 @@ import 'dart:async';
 import 'dart:convert' as convert;
 
 import 'package:dart2_constant/convert.dart' as convert2;
+
+import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/utils.dart';
 
-Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {String schemaVersion}) async {
+Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {SchemaVersion schemaVersion}) async {
   final uriWithFrag = Uri.parse(schemaUrl);
   final uri = schemaUrl.endsWith('#') ? uriWithFrag : uriWithFrag.removeFragment();
   Map schemaMap;

--- a/lib/src/json_schema/vm/platform_functions.dart
+++ b/lib/src/json_schema/vm/platform_functions.dart
@@ -50,7 +50,7 @@ Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {SchemaVersion schema
   final uriWithFrag = Uri.parse(schemaUrl);
   final uri = schemaUrl.endsWith('#') ? uriWithFrag : uriWithFrag.removeFragment();
   Map schemaMap;
-  if (uri.scheme == 'http') {
+  if (uri.scheme == 'http' || uri.scheme == 'https') {
     // Setup the HTTP request.
     final httpRequest = await new HttpClient().getUrl(uri);
     httpRequest.followRedirects = true;

--- a/test/unit/vm/json_schema/invalid_schemas_test.dart
+++ b/test/unit/vm/json_schema/invalid_schemas_test.dart
@@ -79,7 +79,7 @@ void main([List<String> args]) {
             });
 
             try {
-              await JsonSchema.createSchemaAsync(schemaData, schemaVersion: JsonSchemaVersions.draft4);
+              await JsonSchema.createSchemaAsync(schemaData, schemaVersion: SchemaVersion.draft4);
               fail('Schema is expected to be invalid, but was not.');
             } catch (e) {
               catchException(e);

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -84,12 +84,12 @@ void main([List<String> args]) {
   final allDraft6 = testSuiteFolderV6.listSync()..addAll(optionalsV6.listSync());
 
   final runAllTestsForDraftX =
-      (String schemaVersion, List<FileSystemEntity> allTests, List<String> skipFiles, List<String> skipTests,
+      (SchemaVersion schemaVersion, List<FileSystemEntity> allTests, List<String> skipFiles, List<String> skipTests,
           {bool isSync = false, RefProvider refProvider, RefProviderAsync refProviderAsync}) {
-    String shortSchemaVersion = schemaVersion;
-    if (schemaVersion == JsonSchemaVersions.draft4) {
+    String shortSchemaVersion = schemaVersion.toString();
+    if (schemaVersion == SchemaVersion.draft4) {
       shortSchemaVersion = 'draft4';
-    } else if (schemaVersion == JsonSchemaVersions.draft6) {
+    } else if (schemaVersion == SchemaVersion.draft6) {
       shortSchemaVersion = 'draft6';
     }
 
@@ -215,23 +215,23 @@ void main([List<String> args]) {
   final List<String> commonSkippedTests = const [];
 
   // Run all tests asynchronously with no ref provider.
-  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
-  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
+  runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
+  runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
 
   // Run all tests synchronously with a sync ref provider.
-  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
+  runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
       isSync: true, refProvider: syncRefProvider);
-  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
+  runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
       isSync: true, refProvider: syncRefProvider);
 
   // Run all tests asynchronously with an async ref provider.
-  runAllTestsForDraftX(JsonSchemaVersions.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
+  runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests,
       refProviderAsync: asyncRefProvider);
-  runAllTestsForDraftX(JsonSchemaVersions.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
+  runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests,
       refProviderAsync: asyncRefProvider);
 
   group('Schema self validation', () {
-    for (final version in JsonSchemaVersions.allVersions) {
+    for (final version in SchemaVersion.values.map((value) => value.toString())) {
       test('version: $version', () {
         // Pull in the official schema, verify description and then ensure
         // that the schema satisfies the schema for schemas.

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -292,4 +292,51 @@ void main([List<String> args]) {
       expect(isInvalid, isFalse);
     });
   });
+
+  group('examples property', () { 
+    group('in draft4', () {
+      test('should NOT be supported', () {
+        final schema = JsonSchema.createSchema({
+          "type": "string",
+          "examples": ["This", "message", "is", "lost."]
+        }, schemaVersion: SchemaVersion.draft4);
+
+        expect(schema.examples.isEmpty, isTrue);
+      });
+      test('should still pass the default value to the examples getter', () {
+        final schema = JsonSchema.createSchema({
+          "type": "string",
+          "examples": ["This", "message", "is", "lost."],
+          "default": "But this one isn't.",
+        }, schemaVersion: SchemaVersion.draft4);
+
+        expect(schema.examples.length, equals(1));
+        expect(schema.examples.single, equals("But this one isn't."));
+      });
+    });
+
+    group('in draft 6', () {
+      test('should be supported', () {
+        final schema = JsonSchema.createSchema({
+          "type": "string",
+          "examples": ["This", "message", "is", "not", "lost!"]
+        }, schemaVersion: SchemaVersion.draft6);
+
+        expect(schema.examples.length, equals(5));
+        expect(schema.examples[4], equals('lost!'));
+      });
+      test('should append the default value to the examples getter', () {
+        final schema = JsonSchema.createSchema({
+          "type": "string",
+          "examples": ["This", "message", "is", "not", "lost!"],
+          "default": "And neither is this one",
+        }, schemaVersion: SchemaVersion.draft6);
+
+        expect(schema.examples.length, equals(6));
+        expect(schema.examples[0], equals("This"));
+        expect(schema.examples[5], equals("And neither is this one"));
+      });
+    });
+
+  });
 }

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -293,7 +293,7 @@ void main([List<String> args]) {
     });
   });
 
-  group('examples property', () { 
+  group('examples property', () {
     group('in draft4', () {
       test('should NOT be supported', () {
         final schema = JsonSchema.createSchema({
@@ -337,6 +337,5 @@ void main([List<String> args]) {
         expect(schema.examples[5], equals("And neither is this one"));
       });
     });
-
   });
 }


### PR DESCRIPTION
## Ultimate problem:
Need to cut a final 2.0 release, after having used it for a few weeks of testing.

## How it was fixed:
- thoroughly review the spec, and check that we have all constituent properties (manual read of spec) and that they behave as specified (validated with official spec tests).
- add references to each dart getter to the official draft6 spec.
- deprecate unsupported functionality
- rename functions while we still have the chance (
- make the whole `JsonSchema` object serializable with dart's `JSON.encode` via a `toJson` method.

## TODO
- [x] Migration Guide
- [x] Changelog
- [x] Update README

## Testing suggestions:
- ddev test
- read the docs and review for correctness, clarity, grammar, etc.

## Potential areas of regression:
- Whole package, covered by spec tests
