### PR TITLE
CPLAT-4192: Update json_schema to be Dart 2 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,42 @@ dart:
   - stable
 sudo: required
 addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
   chrome: stable
 cache:
   directories:
     - $HOME/.pub-cache
+before_install:
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 script:
   - pub get
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  # TODO: enable coverage when there is a Dart 2 solution.
-  # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,18 @@
 language: dart
-dist: precise
 dart:
   - 1.24.3
+  - stable
+sudo: required
 addons:
-  apt:
-    packages:
-    - ttf-kochi-mincho
-    - ttf-kochi-gothic
-    - ttf-dejavu
-    - ttf-indic-fonts
-    - fonts-tlwg-garuda
-    
-before_install:
-  # Content shell needs this font. Since it has a EULA, we need to manually
-  # install it.
-  #
-  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
-  # fixed.
-  - sudo apt-get update -yq
-  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
-  - sudo apt-get install msttcorefonts -qq
-
-  - mkdir -p bin
-  - export PATH="$PATH:`pwd`/bin/"
-  - ln -s `which chromium-browser` bin/google-chrome
-
-  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
-  - unzip content_shell-linux-x64-release.zip
-  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
-
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 10 # give xvfb some time to start
-
-  - export DARTIUM_EXPIRATION_TIME=$((2**63 -1))
-  - export DART_FLAGS='--checked --load_deferred_eagerly'
+  chrome: stable
+cache:
+  directories:
+    - $HOME/.pub-cache
 script:
-  - pub get --packages-dir
-  - pub run dependency_validator --ignore dart_style,coverage
-  - pub run dart_dev format --check
+  - pub get
+  - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
+  - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  - pub run dart_dev coverage --no-html
-  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  # TODO: enable coverage when there is a Dart 2 solution.
+  # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,42 +4,15 @@ dart:
   - stable
 sudo: required
 addons:
-  apt:
-    packages:
-    - ttf-kochi-mincho
-    - ttf-kochi-gothic
-    - ttf-dejavu
-    - ttf-indic-fonts
-    - fonts-tlwg-garuda
   chrome: stable
 cache:
   directories:
     - $HOME/.pub-cache
-before_install:
-  # Content shell needs this font. Since it has a EULA, we need to manually
-  # install it.
-  #
-  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
-  # fixed.
-  - sudo apt-get update -yq
-  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
-  - sudo apt-get install msttcorefonts -qq
-
-  - mkdir -p bin
-  - export PATH="$PATH:`pwd`/bin/"
-  - ln -s `which chromium-browser` bin/google-chrome
-
-  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
-  - unzip content_shell-linux-x64-release.zip
-  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
-
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
 script:
   - pub get
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
   - pub run dart_dev test
-  - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  # TODO: re-enable coverage when a Dart 2 solution is available.
+  # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,7 +4,6 @@ analyzer:
     - test/src_list.dart
     - node_modules/**
     - packages/**
-    - tool/**
     - test/functional/file_artifacts/**
     - lib/frugal_packages/**
 

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -327,8 +327,7 @@ class JsonSchema {
 
     if (_root == this) {
       if (_retrievalRequests.isNotEmpty) {
-        Future
-            .wait(_retrievalRequests.map((r) => r.asyncRetrievalOperation()))
+        Future.wait(_retrievalRequests.map((r) => r.asyncRetrievalOperation()))
             .then((_) => _thisCompleter.complete(_getSchemaFromPath('#')));
       } else {
         _thisCompleter.complete(_getSchemaFromPath('#'));
@@ -714,7 +713,7 @@ class JsonSchema {
 
   /// Get the anchestry of the current schema, up to the root [JsonSchema].
   List<JsonSchema> get _parents {
-    final parents = [];
+    final parents = <JsonSchema>[];
 
     var circularRefEscapeHatch = 0;
     var nextParent = this._parent;
@@ -1301,7 +1300,7 @@ This functionality will be removed in 3.0.
           return _addSchemaToRefMap(originalRef.toString(), schema);
         } else {
           throw FormatExceptions.error(
-              'Couldn\'t resolve ref: ${_ref} using the ${_refProviderAsync != null ?  'provided' : 'default HTTP(S)' } ref provider.');
+              'Couldn\'t resolve ref: ${_ref} using the ${_refProviderAsync != null ? 'provided' : 'default HTTP(S)'} ref provider.');
         }
       };
 
@@ -1422,8 +1421,8 @@ This functionality will be removed in 3.0.
             uniqueDeps.add(propDep);
           });
         } else {
-          throw FormatExceptions
-              .error('dependency values must be object or array (or boolean in draft6 and later): $v');
+          throw FormatExceptions.error(
+              'dependency values must be object or array (or boolean in draft6 and later): $v');
         }
       });
 
@@ -1438,8 +1437,10 @@ This functionality will be removed in 3.0.
       (k, v) => _makeSchema('$_path/patternProperties/$k', v, (rhs) => _patternProperties[new RegExp(k)] = rhs));
 
   /// Validate, calculate and set the value of the 'required' JSON Schema prop.
-  _setRequired(dynamic value) => _requiredProperties = TypeValidators.nonEmptyList('required', value);
+  _setRequired(dynamic value) =>
+      _requiredProperties = (TypeValidators.nonEmptyList('required', value))?.map((value) => value as String)?.toList();
 
   /// Validate, calculate and set the value of the 'required' JSON Schema prop.
-  _setRequiredV6(dynamic value) => _requiredProperties = TypeValidators.list('required', value);
+  _setRequiredV6(dynamic value) =>
+      _requiredProperties = (TypeValidators.list('required', value))?.map((value) => value as String)?.toList();
 }

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -36,7 +36,7 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'package:uri_template/uri_template.dart' show UriTemplate;
+import 'package:uri/uri.dart' show UriTemplate;
 
 import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,29 +1,30 @@
 name: json_schema
 version: 2.0.0
-
+description: Provide support for validating instances against json schema
 authors:
   - Michael Carter <michael.carter@workiva.com>
   - Daniel Davidson <dbdavidson@yahoo.com>
-  
 homepage: https://github.com/workiva/json_schema
-description: >
-  Provide support for validating instances against json schema
+
 environment:
-  sdk: '>=1.24.0 <3.0.0'
+  sdk: ">=1.24.3 <3.0.0"
 
 dependencies:
-  args: '>=0.11.0 <2.0.0'
+  args: ">=0.13.7 <2.0.0"
   dart2_constant: ^1.0.0
-  logging: '>=0.9.3<0.12.0'
-  path: '^1.3.0'
-  uri_template: ^0.6.0
-  w_transport: ^3.1.2
+  logging: ">=0.9.3 <0.12.0"
+  path: ^1.3.0
+  uri: ">=0.11.1 <0.12.0"
+  w_transport: ^3.2.8
 
 dev_dependencies:
-  coverage: '>=0.7.6'
-  dart_dev: any
-  dart_style: any
-  dependency_validator: ^1.0.0
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <2.0.0"
+  coverage: ">=0.10.0 <0.13.0"
+  dart_dev: ^2.0.0
+  dart_style: ^1.0.9
+  dependency_validator: ^1.2.1
   shelf: ^0.7.2
   shelf_static: ^0.2.7
-  test: '^0.12.13'
+  test: ">=0.12.30 <2.0.0"

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -123,8 +123,7 @@ void main([List<String> args]) {
                   expect(validationResult, expectedResult);
                 } else {
                   final checkResult = expectAsync0(() => expect(validationResult, expectedResult));
-                  JsonSchema
-                      .createSchemaAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProviderAsync)
+                  JsonSchema.createSchemaAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProviderAsync)
                       .then((schema) {
                     validationResult = schema.validate(instance);
                     checkResult();

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -63,7 +63,7 @@ main(List<String> args) async {
     new TestRunnerConfig(directory: 'test/unit/vm', env: Environment.vm, filename: 'generated_runner_test'),
   ];
 
-  config.test.platforms = ['vm', 'content-shell'];
+  config.test.platforms = ['vm', 'chrome'];
 
   config.test.unitTests = const [
     'test/unit/browser/generated_runner_test.dart',


### PR DESCRIPTION
## Overview:

Update ```json_schema``` to be Dart 2 compatible.  

## Testing suggestions:

- [ ] CI passes on Dart 1 and Dart 2  

## Potential areas of regression:

- None, but it might be worth running a few consumer tests. 

---

> __FYA:__ @michaelcarter-wf @corwinsheahan-wf @evanweible-wf @seanburke-wf @smaifullerton-wk 