### PR TITLE
WAP-2519: Support relative filesystem refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ cache:
 script:
   - pub get
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
-  - pub2 run dart_dev dart2-only -- format --check
-  - pub2 run dart_dev analyze
+  - pub run dart_dev dart2-only -- format --check
+  - pub run dart_dev analyze
   - pub run dart_dev test
   # TODO: re-enable coverage when a Dart 2 solution is available.
   # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 dart:
   - 1.24.3
-  - stable
+  - 2.1.1
 sudo: required
 addons:
   chrome: stable
@@ -11,8 +11,8 @@ cache:
 script:
   - pub get
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
-  - pub run dart_dev dart2-only -- format --check
-  - pub run dart_dev analyze
+  - pub2 run dart_dev dart2-only -- format --check
+  - pub2 run dart_dev analyze
   - pub run dart_dev test
   # TODO: re-enable coverage when a Dart 2 solution is available.
   # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1037,8 +1037,8 @@ class JsonSchema {
   /// validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath]
   /// to get the [JsonSchema] at any path, instead.
   @Deprecated('''
-Note: This information is useful for drawing dependency graphs, etc, but should not be used for general 
-validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath] 
+Note: This information is useful for drawing dependency graphs, etc, but should not be used for general
+validation or traversal. Use [endPath] to get the absolute [String] path and [resolvePath]
 to get the [JsonSchema] at any path, instead.
 
 This functionality will be removed in 3.0.
@@ -1292,7 +1292,6 @@ This functionality will be removed in 3.0.
   _setRef(dynamic value) {
     _ref = TypeValidators.uri(r'$ref', value);
     final Uri originalRef = Uri.parse(_ref.toString());
-
     // TODO: add a more advanced check to find out if the $ref is local.
     // Does it have a fragment? Append the base and check if it exists in the _refMap
     // Does it have a path? Append the base and check if it exists in the _refMap
@@ -1305,14 +1304,15 @@ This functionality will be removed in 3.0.
           template += '#${_ref.fragment}';
         }
         _ref = Uri.parse(template);
-
         // If the $id has a fragment, append it to the base, or use it alone.
       } else if (_ref.fragment != null && _ref.fragment.isNotEmpty) {
         _ref = Uri.parse('${_inheritedUri ?? ''}#${_ref.fragment}');
       }
     }
 
-    if (_ref.scheme.isNotEmpty) {
+    // The ref's base is a relative file path, so it should be treated as a relative file URI
+    final isRelativeFileUri = _inheritedUriBase != null && _inheritedUriBase.scheme.isEmpty;
+    if (_ref.scheme.isNotEmpty || isRelativeFileUri) {
       // TODO: should we do something if the ref is a fragment?
       final addSchemaFunction = (JsonSchema schema) {
         if (schema != null) {

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -79,6 +79,10 @@ class JsonSchemaUtils {
     if (uri.pathSegments.isNotEmpty /* && uri.pathSegments.last.endsWith('.json')*/) {
       segments = []..addAll(uri.pathSegments);
       segments.removeLast();
+
+      if (uri.scheme == 'file' || uri.scheme == '') {
+        return new Uri.file(segments.join('/'));
+      }
       return new Uri(scheme: uri.scheme, host: uri.host, port: uri.port, pathSegments: segments);
     }
     return uri;

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -80,10 +80,7 @@ class JsonSchemaUtils {
       segments = []..addAll(uri.pathSegments);
       segments.removeLast();
 
-      if (uri.scheme == 'file' || uri.scheme == '') {
-        return new Uri.file(segments.join('/'));
-      }
-      return new Uri(scheme: uri.scheme, host: uri.host, port: uri.port, pathSegments: segments);
+      return uri.replace(pathSegments: segments);
     }
     return uri;
   }

--- a/test/relative_refs/root.json
+++ b/test/relative_refs/root.json
@@ -1,0 +1,11 @@
+{
+  "$id": "root.json",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Root Schema",
+  "description": "A schema with relative refs to other schema files",
+  "type": "object",
+  "properties": {
+    "integer": {"$ref": "subdir/integer.json"},
+    "string": {"$ref": "string.json"}
+  }
+}

--- a/test/relative_refs/string.json
+++ b/test/relative_refs/string.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/test/relative_refs/subdir/integer.json
+++ b/test/relative_refs/subdir/integer.json
@@ -1,0 +1,4 @@
+{
+    "$id": "some_id_that_doesn't_match_ref#",
+    "type": "integer"
+}

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -337,4 +337,13 @@ void main([List<String> args]) {
       });
     });
   });
+
+  test('Schema from relative filesystem URI should be supported', () async {
+    // this assumes that tests are run from the root directory of the project
+    final schema = await JsonSchema.createSchemaFromUrl('test/relative_refs/root.json');
+
+    expect(schema.validate({"string": 123, "integer": 123}), isFalse);
+    expect(schema.validate({"string": "a string", "integer": "a string"}), isFalse);
+    expect(schema.validate({"string": "a string", "integer": 123}), isTrue);
+  });
 }


### PR DESCRIPTION
## Ultimate problem:

`$ref` values to relative file paths were not resolving correctly

## How it was fixed:

Made a couple of small tweaks to URL handling to ensure that relative paths are preserved, rather than turning into absolute URIs.

## Testing suggestions:

Tests added which should cover it.

## Potential areas of regression:

N/A -- all tests pass.

---

> __FYA:__ @michaelcarter-wf