### PR TITLE
WAP-2536: Address failing tests on Dart 2.2

### DIFF
--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -211,7 +211,16 @@ void main([List<String> args]) {
 
   final List<String> commonSkippedFiles = const [];
 
-  final List<String> commonSkippedTests = const [];
+  /// A list of tests to skip for all drafts.
+  /// Should match the portion of the test name printed after the JSON file name on test run.
+  final List<String> commonSkippedTests = const [
+    // Parsing of large numbers in JSON changed in Dart 2.2, resulting in
+    // a more accurate representation of the input, but a type of `double`.
+    // Previous versions of Dart pass this test, but the integer output is not
+    // equivalent to the JSON input.
+    'integer : a bignum is an integer',
+    'integer : a negative bignum is an integer',
+  ];
 
   // Run all tests asynchronously with no ref provider.
   runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);


### PR DESCRIPTION
## Ultimate problem:

JSON parsing in Dart 2.2 changed for large numbers. On versions 2.1.1 and before (tested specifically on 1.24.3 & 2.1.1), the bignum inputs converted as follows:

```
JSON input: 12345678910111213141516171819202122232425262728293031
Dart value: 942084304541264551
```

while the conversion was wrong, tests in `bignum.json` only pertain to type checking, so they passed.

On the other hand, Dart 2.2 converts the same number like so:

```
JSON input: 12345678910111213141516171819202122232425262728293031
Dart value: 1.2345678910111214e+52
```

This is obviously more accurate, but Dart had to use a double type to represent a number this large. So the tests for integer types fail.

## How it was fixed:

I decided that it's best to just skip these tests, for a few reasons:

1. Inconsistencies between Dart versions
2. Prior versions of Dart, where the tests passed, still didn't handle the numbers properly
3. These are in the "optional" directory, so passing every test here is not mission critical
4. I'm not sure that there's a good solution here without causing other tests to fail

## Testing suggestions:

N/A

## Potential areas of regression:

N/A


---

> __FYA:__ @michaelcarter-wf