### PR TITLE
WAP-2482: Use DeepCollectionEquality for hashcode and == operator

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -703,10 +703,11 @@ class JsonSchema {
   JsonSchema resolvePath(String path) => _getSchemaFromPath(path);
 
   @override
-  bool operator ==(dynamic other) => other is JsonSchema && new MapEquality().equals(schemaMap, other.schemaMap);
+  bool operator ==(dynamic other) =>
+      other is JsonSchema && new DeepCollectionEquality().equals(schemaMap, other.schemaMap);
 
   @override
-  int get hashCode => new MapEquality().hash(schemaMap);
+  int get hashCode => new DeepCollectionEquality().hash(schemaMap);
 
   @override
   String toString() => '${_schemaMap}';


### PR DESCRIPTION
## Ultimate problem:
- `MapEquality` was used to check if 2 schema's were equal, which returns false if the schemas contain `enumValues`

## How it was fixed:
- Use `DeepCollectionEquality` for comparing schema maps, as this will evaluate nested collections as well.

## Testing suggestions:
- Compare 2 separate yet identical schema's that contain `enumValues`.

## Potential areas of regression:
- Schema comparing


---

> __FYA:__ @michaelcarter-wf