### PR TITLE
WAP-2881: Tweak error string for root level errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
 cache:
   directories:
     - $HOME/.pub-cache
+install: false
 script:
   # Use pub 2 for Dart 1.
   - if [[ $(dart dart_version.dart) = "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,19 @@ cache:
   directories:
     - $HOME/.pub-cache
 script:
-  - pub get
+  # Use pub 2 for Dart 1.
+  - |
+    if [[ $(dart dart_version.dart) = "1" ]]; then
+      curl --connect-timeout 15 --retry 5 https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > ${TRAVIS_HOME}/dartsdk2.zip
+      unzip ${TRAVIS_HOME}/dartsdk2.zip -d ${TRAVIS_HOME}/dart2 > /dev/null
+      rm ${TRAVIS_HOME}/dartsdk2.zip
+      _PUB_TEST_SDK_VERSION=1.24.3 timeout 5m ${TRAVIS_HOME}/dart2/dart-sdk/bin/pub get --no-precompile
+    fi
+  # Use normal "pub get" for Dart 2.
+  - |
+    if [[ $(dart dart_version.dart) = "2" ]]; then
+      pub get
+    fi
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,16 @@ cache:
 install: true
 script:
   # Use pub 2 for Dart 1.
-  - if [[ $(dart dart_version.dart) = "1" ]]; then
+  - |
+    if [[ $(dart dart_version.dart) = "1" ]]; then
       curl --connect-timeout 15 --retry 5 https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > ${TRAVIS_HOME}/dartsdk2.zip
       unzip ${TRAVIS_HOME}/dartsdk2.zip -d ${TRAVIS_HOME}/dart2 > /dev/null
       rm ${TRAVIS_HOME}/dartsdk2.zip
       _PUB_TEST_SDK_VERSION=1.24.3 timeout 5m ${TRAVIS_HOME}/dart2/dart-sdk/bin/pub get --no-precompile
     fi
   # Use normal "pub get" for Dart 2.
-  - if [[ $(dart dart_version.dart) = "2" ]]; then
+  - |
+    if [[ $(dart dart_version.dart) = "2" ]]; then
       pub get
     fi
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,14 @@ cache:
     - $HOME/.pub-cache
 script:
   # Use pub 2 for Dart 1.
-  - |
-    if [[ $(dart dart_version.dart) = "1" ]]; then
+  - if [[ $(dart dart_version.dart) = "1" ]]; then
       curl --connect-timeout 15 --retry 5 https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > ${TRAVIS_HOME}/dartsdk2.zip
       unzip ${TRAVIS_HOME}/dartsdk2.zip -d ${TRAVIS_HOME}/dart2 > /dev/null
       rm ${TRAVIS_HOME}/dartsdk2.zip
       _PUB_TEST_SDK_VERSION=1.24.3 timeout 5m ${TRAVIS_HOME}/dart2/dart-sdk/bin/pub get --no-precompile
     fi
   # Use normal "pub get" for Dart 2.
-  - |
-    if [[ $(dart dart_version.dart) = "2" ]]; then
+  - if [[ $(dart dart_version.dart) = "2" ]]; then
       pub get
     fi
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 cache:
   directories:
     - $HOME/.pub-cache
-install: false
+install: true
 script:
   # Use pub 2 for Dart 1.
   - if [[ $(dart dart_version.dart) = "1" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
+## 2.1.5
+
+* Omit colon in error string when instance path is empty
+
+## 2.1.4
+
+* Use deep equality to compare maps, fixing equality when enums are present
+
+## 2.1.3
+
+* New `validateWithErrors` method on `JsonSchema` returns all validation errors as a list of objects
+* `ValidationError` objects include both instance & schema paths for each error
+* Error logic tweaked to provide consistent error paths in JSON pointer notation
+
 ## 2.0.0
 
 * json_schema is no longer bound to dart:io and works in the browser!
 * Full JSON Schema draft6 compatibility
 * Much better $ref resolution, including deep nesting of $refs
 * More typed keyword getters for draft6 like `examples`
-* Syncronous schema evaluation by default 
+* Syncronous schema evaluation by default
 * Optional async evaluation and fetching with `createSchemaAsync`
 * Automatic parsing of JSON strings passed to `createSchema` and `createSchemaAsync`
 * Ability to do custom resolution of $refs with `RefProvider` and `RefProviderAsync`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.5
 
-* Omit colon in error string when instance path is empty
+* Add note about root path in error string when instance path is empty
 
 ## 2.1.4
 

--- a/dart_version.dart
+++ b/dart_version.dart
@@ -1,0 +1,5 @@
+import 'dart:io';
+
+main() {
+  print(Platform.version.split('.').first);
+}

--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -39,5 +39,5 @@
 export 'package:json_schema/src/json_schema/json_schema.dart' show JsonSchema;
 export 'package:json_schema/src/json_schema/constants.dart' show SchemaVersion;
 export 'package:json_schema/src/json_schema/schema_type.dart' show SchemaType;
-export 'package:json_schema/src/json_schema/validator.dart' show Validator;
+export 'package:json_schema/src/json_schema/validator.dart' show Validator, ValidationError;
 export 'package:json_schema/src/json_schema/typedefs.dart' show RefProvider, RefProviderAsync;

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -71,7 +71,7 @@ class ValidationError {
   String message;
 
   @override
-  toString() => instancePath.isEmpty ? message : '$instancePath: $message';
+  toString() => '${instancePath.isEmpty ? '# (root)': instancePath}: $message';
 }
 
 /// Initialized with schema, validates instances against it

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -71,7 +71,7 @@ class ValidationError {
   String message;
 
   @override
-  toString() => '$instancePath: $message';
+  toString() => instancePath.isEmpty ? message : '$instancePath: $message';
 }
 
 /// Initialized with schema, validates instances against it

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -71,7 +71,7 @@ class ValidationError {
   String message;
 
   @override
-  toString() => '${instancePath.isEmpty ? '# (root)': instancePath}: $message';
+  toString() => '${instancePath.isEmpty ? '# (root)' : instancePath}: $message';
 }
 
 /// Initialized with schema, validates instances against it

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -59,7 +59,7 @@ class Instance {
 }
 
 class ValidationError {
-  ValidationError(this.instancePath, this.schemaPath, this.message);
+  ValidationError._(this.instancePath, this.schemaPath, this.message);
 
   /// Path in the instance data to the key where this error occurred
   String instancePath;
@@ -527,7 +527,7 @@ class Validator {
     // _logger.warning(msg); TODO: re-add logger
 
     schemaPath = schemaPath.replaceFirst('#', '');
-    _errors.add(new ValidationError(instancePath, schemaPath, msg));
+    _errors.add(new ValidationError._(instancePath, schemaPath, msg));
     if (!_reportMultipleErrors) throw new FormatException(msg);
   }
 

--- a/test/unit/vm/json_schema/validation_error_test.dart
+++ b/test/unit/vm/json_schema/validation_error_test.dart
@@ -11,7 +11,7 @@ JsonSchema createObjectSchema(Map<String, dynamic> nestedSchema) {
 }
 
 void main() {
-  group('validation error', () {
+  group('ValidationError', () {
     test('boolean false at root', () {
       final schema = JsonSchema.createSchema(false);
       final errors = schema.validateWithErrors({'someKey': 1});
@@ -577,6 +577,31 @@ void main() {
       expect(errors[0].instancePath, '/someKey');
       expect(errors[0].schemaPath, '/properties/someKey/dependencies/bar');
       expect(errors[0].message, contains('schema dependency'));
+    });
+
+    group('string formatting', () {
+      final schema = JsonSchema.createSchema({
+        "properties": {
+          "foo": {"type": "string"},
+          "bar": {"type": "integer"}
+        },
+        "required": ["foo"]
+      });
+
+      test('with an instance path should include the path', () {
+        final errors = schema.validateWithErrors({
+          'foo': 'some string',
+          'bar': 'oops this should be an integer'
+        });
+        expect(errors.length, 1);
+        expect(errors[0].toString().startsWith('/bar:'), isTrue);
+      });
+
+      test('without an instance path should omit the colon', () {
+        final errors = schema.validateWithErrors({});
+        expect(errors.length, 1);
+        expect(errors[0].toString(), 'required prop missing: foo from {}');
+      });
     });
 
     group('reference', () {

--- a/test/unit/vm/json_schema/validation_error_test.dart
+++ b/test/unit/vm/json_schema/validation_error_test.dart
@@ -594,10 +594,10 @@ void main() {
         expect(errors[0].toString().startsWith('/bar:'), isTrue);
       });
 
-      test('without an instance path should omit the colon', () {
+      test('without an instance path should add "root" instead of the path', () {
         final errors = schema.validateWithErrors({});
         expect(errors.length, 1);
-        expect(errors[0].toString(), 'required prop missing: foo from {}');
+        expect(errors[0].toString(), '# (root): required prop missing: foo from {}');
       });
     });
 

--- a/test/unit/vm/json_schema/validation_error_test.dart
+++ b/test/unit/vm/json_schema/validation_error_test.dart
@@ -589,10 +589,7 @@ void main() {
       });
 
       test('with an instance path should include the path', () {
-        final errors = schema.validateWithErrors({
-          'foo': 'some string',
-          'bar': 'oops this should be an integer'
-        });
+        final errors = schema.validateWithErrors({'foo': 'some string', 'bar': 'oops this should be an integer'});
         expect(errors.length, 1);
         expect(errors[0].toString().startsWith('/bar:'), isTrue);
       });


### PR DESCRIPTION
Error strings were always prepending the instance path even when empty, leading to root level errors like this:

```
: required prop missing: id from {"foo": "bar"}
```

An empty path is correct for anything at the root level (see the [JSON Pointer](https://tools.ietf.org/html/rfc6901) spec), so this PR just removes the prepended colon if the instance path is empty.