### PR TITLE
CPLAT-6437: Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -161,7 +161,7 @@ main(List<String> args) {
     new HttpClient()
         .getUrl(uri)
         .then((HttpClientRequest request) => request.close())
-        .then((HttpClientResponse response) => response.transform(new convert.Utf8Decoder()).join())
+        .then((HttpClientResponse response) => new convert.Utf8Decoder().bind(response).join())
         .then((text) {
       completer.complete(text);
     });

--- a/lib/src/json_schema/vm/platform_functions.dart
+++ b/lib/src/json_schema/vm/platform_functions.dart
@@ -60,7 +60,7 @@ Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {SchemaVersion schema
     if (response.statusCode == HttpStatus.NOT_FOUND) {
       throw new ArgumentError('Schema at URL: $schemaUrl can\'t be found.');
     }
-    final schemaText = await response.transform(new convert.Utf8Decoder()).join();
+    final schemaText = await new convert.Utf8Decoder().bind(response).join();
     schemaMap = convert2.json.decode(schemaText);
   } else if (uri.scheme == 'file' || uri.scheme == '') {
     final fileString = await new File(uri.scheme == 'file' ? uri.toFilePath() : schemaUrl).readAsString();


### PR DESCRIPTION
# [CPLAT-6437](https://jira.atl.workiva.net/browse/CPLAT-6437)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-6437)

An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900

## Ultimate problem:


## How it was fixed:


## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf