### PR TITLE
CPLAT-6438: Fix TravisCI for Dart 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,7 @@ cache:
     - $HOME/.pub-cache
 install: true
 script:
-  # Use pub 2 for Dart 1.
-  - |
-    if [[ $(dart dart_version.dart) = "1" ]]; then
-      curl --connect-timeout 15 --retry 5 https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > ${TRAVIS_HOME}/dartsdk2.zip
-      unzip ${TRAVIS_HOME}/dartsdk2.zip -d ${TRAVIS_HOME}/dart2 > /dev/null
-      rm ${TRAVIS_HOME}/dartsdk2.zip
-      _PUB_TEST_SDK_VERSION=1.24.3 timeout 5m ${TRAVIS_HOME}/dart2/dart-sdk/bin/pub get --no-precompile
-    fi
-  # Use normal "pub get" for Dart 2.
-  - |
-    if [[ $(dart dart_version.dart) = "2" ]]; then
-      pub get
-    fi
+  - pub get
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,20 @@ cache:
     - $HOME/.pub-cache
 install: true
 script:
-  - pub get
+  # Use pub 2 for Dart 1.
+  - |
+    if [[ $(dart dart_version.dart) = "1" ]]; then
+      curl --connect-timeout 15 --retry 5 https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > ${TRAVIS_HOME}/dartsdk2.zip
+      unzip ${TRAVIS_HOME}/dartsdk2.zip -d ${TRAVIS_HOME}/dart2 > /dev/null
+      rm ${TRAVIS_HOME}/dartsdk2.zip
+      _PUB_TEST_SDK_VERSION=1.24.3 timeout 5m ${TRAVIS_HOME}/dart2/dart-sdk/bin/pub get --no-precompile
+      pub get
+    fi
+  # Use normal "pub get" for Dart 2.
+  - |
+    if [[ $(dart dart_version.dart) = "2" ]]; then
+      pub get
+    fi
   - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
 RUN chmod 700 /root/.ssh/
 RUN chmod 600 /root/.ssh/id_rsa
 
-RUN pub global activate -sgit git@github.com:Workiva/semver-audit-dart.git
+RUN pub global activate --hosted-url https://pub.workiva.org semver_audit ^2.0.1
 
 COPY pubspec.yaml ./
 RUN pub get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.1.0
+FROM google/dart:2.4.0
 WORKDIR /build/
 
 # Build Environment Vars


### PR DESCRIPTION
# [CPLAT-6438](https://jira.atl.workiva.net/browse/CPLAT-6438)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-6438)

# Fixes Travis CI under Dart 1 by:
 - Add a pub 1 get after pub 2 get
 - Updating the version of Dart docker base image to be able to
 - Install semver from a hosted pub server

# Testing
 - CI passes on Dart 1 now