### PR TITLE
CPLAT-7426 Run Dart 2 unit tests with dart2js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ script:
     if [[ $(dart dart_version.dart) = "2" ]]; then
       pub get
     fi
-  - pub run dependency_validator --ignore build_runner,build_test,build_web_compilers,dart_style,coverage
+  - pub run dependency_validator --ignore coverage
   - pub run dart_dev dart2-only -- format --check
   - pub run dart_dev analyze
-  - pub run dart_dev test
+  - pub run dart_dev test -p vm
+  - pub run dart_dev test -p chrome --release
   # TODO: re-enable coverage when a Dart 2 solution is available.
   # - pub run dart_dev dart1-only -- coverage --no-html && bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
-  dependency_validator: ^1.2.1
+  dependency_validator: ^1.3.0
   shelf: ^0.7.2
   shelf_static: ^0.2.7
   test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
## Ultimate problem:
We'll soon be shipping unified Wdesk to production compiled with Dart 2/dart2js. Running the browser unit tests with the same compiler would increase our confidence in the code we're shipping to production.

## How it was fixed:
- Updated CI to run the browser-based unit tests in production mode.
- Upgraded to a newer version of dependency_validator that automatically ignores some common dependencies used only for their binaries.

## Testing suggestions:
- [ ] Confirm CI passes

## Potential areas of regression:
CI


---

> __FYA:__ @michaelcarter-wf