### PR TITLE
PROC-728: Fix Encoding and UTF-16 Spec Tests

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1522,7 +1522,7 @@ class JsonSchema {
   _setOneOf(dynamic value) => _validateListOfSchema('oneOf', value, (schema) => _oneOf.add(schema));
 
   /// Validate, calculate and set the value of the 'pattern' JSON Schema prop.
-  _setPattern(dynamic value) => _pattern = RegExp(TypeValidators.string('pattern', value));
+  _setPattern(dynamic value) => _pattern = RegExp(TypeValidators.string('pattern', value), unicode: true);
 
   /// Validate, calculate and set the value of the 'propertyNames' JSON Schema prop.
   _setPropertyNames(dynamic value) {
@@ -1663,8 +1663,9 @@ class JsonSchema {
   _setMinProperties(dynamic value) => _minProperties = TypeValidators.nonNegativeInt('minProperties', value);
 
   /// Validate, calculate and set the value of the 'patternProperties' JSON Schema prop.
-  _setPatternProperties(dynamic value) => (TypeValidators.object('patternProperties', value)).forEach((k, v) =>
-      _createOrRetrieveSchema('$_path/patternProperties/$k', v, (rhs) => _patternProperties[RegExp(k)] = rhs));
+  _setPatternProperties(dynamic value) =>
+      (TypeValidators.object('patternProperties', value)).forEach((k, v) => _createOrRetrieveSchema(
+          '$_path/patternProperties/$k', v, (rhs) => _patternProperties[RegExp(k, unicode: true)] = rhs));
 
   /// Validate, calculate and set the value of the 'required' JSON Schema prop.
   _setRequired(dynamic value) =>

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -40,6 +40,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:json_pointer/json_pointer.dart';
 
 import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/format_exceptions.dart';
@@ -471,7 +472,13 @@ class JsonSchema {
             } else if (schemaValues is Map<String, JsonSchema>) {
               // Map properties use the following fragment to fetch the value by key.
               i += 1;
-              final String propertyKey = fragments[i];
+              String propertyKey = fragments[i];
+              if (schemaValues[propertyKey] is! JsonSchema) {
+                try {
+                  propertyKey = Uri.decodeQueryComponent(propertyKey);
+                  propertyKey = unescape(propertyKey);
+                } catch (e) {}
+              }
               currentSchema = schemaValues[propertyKey];
 
               // Fetched properties must be valid schemas.

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -36,7 +36,6 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import 'package:json_pointer/json_pointer.dart' as json_pointer;
 import 'package:uri/uri.dart' show UriTemplate;
 
 import 'package:json_schema/src/json_schema/constants.dart';
@@ -84,11 +83,6 @@ class JsonSchemaUtils {
       return uri.replace(pathSegments: segments);
     }
     return uri;
-  }
-
-  static String uriEncodeAndJsonPointerEscapePropertyName(String propertyName) {
-    final pointerEscapedKey = json_pointer.escape(propertyName);
-    return Uri.encodeComponent(pointerEscapedKey);
   }
 }
 

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -36,6 +36,7 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
+import 'package:json_pointer/json_pointer.dart' as json_pointer;
 import 'package:uri/uri.dart' show UriTemplate;
 
 import 'package:json_schema/src/json_schema/constants.dart';
@@ -83,6 +84,11 @@ class JsonSchemaUtils {
       return uri.replace(pathSegments: segments);
     }
     return uri;
+  }
+
+  static String uriEncodeAndJsonPointerEscapePropertyName(String propertyName) {
+    final pointerEscapedKey = json_pointer.escape(propertyName);
+    return Uri.encodeComponent(pointerEscapedKey);
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ environment:
 dependencies:
   args: ">=0.13.7 <2.0.0"
   collection: ^1.14.6
+  json_pointer: ^0.1.0
   logging: ">=0.9.3 <0.12.0"
   path: ^1.3.0
   uri: ">=0.11.1 <0.12.0"
   w_transport: ^3.2.8
-  json_pointer: ^0.1.0
 
 dev_dependencies:
   build_runner: ^1.7.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   path: ^1.3.0
   uri: ">=0.11.1 <0.12.0"
   w_transport: ^3.2.8
+  json_pointer: ^0.1.0
 
 dev_dependencies:
   build_runner: ^1.7.2

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -260,11 +260,6 @@ void main([List<String> args]) {
     'integer : a bignum is an integer',
     'integer : a negative bignum is an integer',
     // Skip new tests from the spec that we don't pass yet:
-    'refs with quote : object with numbers is valid',
-    'refs with quote : object with strings is invalid',
-    'Proper UTF-16 surrogate pair handling: pattern : matches empty',
-    'Proper UTF-16 surrogate pair handling: pattern : matches two',
-    'Proper UTF-16 surrogate pair handling: patternProperties : doesn\'t match two',
     'all integers are multiples of 0.5, if overflow is handled : valid if optional overflow handling is implemented',
   ];
 

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -260,12 +260,6 @@ void main([List<String> args]) {
     'integer : a bignum is an integer',
     'integer : a negative bignum is an integer',
     // Skip new tests from the spec that we don't pass yet:
-    'escaped pointer ref : slash invalid',
-    'escaped pointer ref : tilde invalid',
-    'escaped pointer ref : percent invalid',
-    'escaped pointer ref : slash valid',
-    'escaped pointer ref : tilde valid',
-    'escaped pointer ref : percent valid',
     'refs with quote : object with numbers is valid',
     'refs with quote : object with strings is invalid',
     'Proper UTF-16 surrogate pair handling: pattern : matches empty',
@@ -275,8 +269,8 @@ void main([List<String> args]) {
   ];
 
   // Run all tests asynchronously with no ref provider.
-  runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
-  runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
+  // runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
+  // runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
 
   // Run all tests synchronously with a sync ref provider.
   runAllTestsForDraftX(

--- a/test/unit/vm/json_schema/validation_test.dart
+++ b/test/unit/vm/json_schema/validation_test.dart
@@ -264,8 +264,18 @@ void main([List<String> args]) {
   ];
 
   // Run all tests asynchronously with no ref provider.
-  // runAllTestsForDraftX(SchemaVersion.draft4, allDraft4, commonSkippedFiles, commonSkippedTests);
-  // runAllTestsForDraftX(SchemaVersion.draft6, allDraft6, commonSkippedFiles, commonSkippedTests);
+  runAllTestsForDraftX(
+    SchemaVersion.draft4,
+    allDraft4,
+    commonSkippedFiles,
+    commonSkippedTests,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft6,
+    allDraft6,
+    commonSkippedFiles,
+    commonSkippedTests,
+  );
 
   // Run all tests synchronously with a sync ref provider.
   runAllTestsForDraftX(


### PR DESCRIPTION
## Ultimate problem:
- We weren't passing some spec tests related to:
  - UTF-16 encoding of the `pattern` property (regexes)
  - JSON Pointer and URI encoding of property names in `definitions` / `properties` / custom properties
 
## How it was fixed:
- Enable unicode on RegExp construction
- If searching for an encoded property name fails URI and JSON Pointer decode it and try again.

## Testing suggestions:


## Potential areas of regression:

---

> __FYA:__ @michaelcarter-wf