### PR TITLE
Raise w_transport max to <5.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ">=0.9.3 <0.12.0"
   path: ^1.3.0
   uri: ">=0.11.1 <0.12.0"
-  w_transport: ^3.2.8
+  w_transport: ">=3.2.8 <5.0.0"
 
 dev_dependencies:
   build_runner: ^1.7.2

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -2,14 +2,7 @@ import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 
 final config = {
-  'analyze': AnalyzeTool()
-    ..analyzerArgs = ['--fatal-warnings']
-    ..include = [
-      Glob('bin/'),
-      Glob('lib/'),
-      Glob('test/'),
-      Glob('tool/'),
-    ],
+  'analyze': AnalyzeTool(),
   'format': FormatTool()..formatterArgs = ['--line-length=120'],
   'serve': WebdevServeTool()..webdevArgs = ['web:9000'],
   'test': TestTool(),


### PR DESCRIPTION
## Ultimate problem:
We're updating to w_transport v4. This is the first step to raise the upper bound. 2nd step will be to raise the lower bound.

## How it was fixed:
Edit the pubspec to allow <5.0.0 for w_transport

## Potential areas of regression:
Network calls that use w_transport


---

> __FYA:__ @michaelcarter-wf