### PR TITLE
Raise Max Versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,16 +10,16 @@ environment:
   sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
-  args: ">=0.13.7 <2.0.0"
+  args: '>=0.13.7 <3.0.0'
   collection: ^1.14.6
   json_pointer: ^0.1.0
-  logging: ">=0.9.3 <0.12.0"
+  logging: '>=0.9.3 <2.0.0'
   path: ^1.3.0
-  uri: ">=0.11.1 <0.12.0"
+  uri: '>=0.11.1 <2.0.0'
   w_transport: ">=3.2.8 <5.0.0"
 
 dev_dependencies:
-  build_runner: ^1.7.2
+  build_runner: '>=1.7.2 <3.0.0'
   build_test: ^0.10.10
   build_web_compilers: ^2.9.0
   build_vm_compilers: ^1.0.4


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)