### PR TITLE
fix(package): don't depend on dart_dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SHELL                    := /bin/bash
+
+.PHONY: pubget
+pubget:
+	dart pub get
+
+.PHONY: format
+format:
+	dart format -l 120 .
+
+.PHONY: analyze
+analyze:
+	dart analyze
+
+.PHONY: test
+test:
+	dart test

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ SHELL                    := /bin/bash
 pubget:
 	dart pub get
 
+.PHONY: dependency_validator
+dependency_validator:
+	dart run dependency_validator
+
 .PHONY: format
 format:
 	dart format -l 120 .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
   A *platform agnostic* (web, flutter or vm) Dart library for validating JSON instances against JSON Schemas (multi-version support with latest of Draft 7).
 
+## Getting Started
+
+1. Ensure you have stable Dart installed.
+2. `make pubget`
+3. `make format`
+4. `make analyze`
+5. `make test`
+
 ## How To Create and Validate Against a Schema
   
 ### Synchronous Creation - Self Contained

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   w_transport: ^4.0.0
 
 dev_dependencies:
-  dependency_validator: ^1.4.0
+  dependency_validator: ^3.1.2
   shelf: ^0.7.2
   shelf_static: ^0.2.7
   test: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   w_transport: ^4.0.0
 
 dev_dependencies:
-  dart_dev: ^3.6.1
   dependency_validator: ^1.4.0
   shelf: ^0.7.2
   shelf_static: ^0.2.7

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -1,6 +1,0 @@
-import 'package:dart_dev/dart_dev.dart';
-
-final config = {
-  ...coreConfig,
-  'format': FormatTool()..formatterArgs = ['--line-length=120'],
-};


### PR DESCRIPTION
## Ultimate problem:
- dart_dev isn't null safe yet, and we use it very minimally

## How it was fixed:
- remove the dependency in favor of a short Makefile
- update readme to make it more clear how to get started developing

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf