### PR TITLE
imp(package): deprecate schema providers, rename top-level factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,19 @@
 
 ## Getting Started
 
-1. Ensure you have stable Dart installed.
+1. Ensure you have latest stable Dart installed.
 2. `make pubget`
 3. `make format`
 4. `make analyze`
 5. `make test`
 
-## How To Create and Validate Against a Schema
-  
-### Synchronous Creation - Self Contained
-  
-The simplest way to create a schema is to pass JSON data directly to `JsonSchema.createSchema` with a JSON `String`, or decoded JSON via Dart `Map` or `bool`. 
+## Simple Example Usage
+
+The simplest way to create a schema is to pass JSON data directly to `JsonSchema.create` with a JSON `String`, or decoded JSON via Dart `Map` or `bool`. 
 
 After creating any schema, JSON instances can be validated by calling `.validate(instance)` on that schema. By default, instances are expected to be pre-parsed JSON as native dart primitives (`Map`, `List`, `String`, `bool`, `num`, `int`). You can also optionally parse at validation time by passing in a string and setting `parseJson`: `schema.validate('{ "name": "any JSON object"}', parseJson: true)`.
-    
+
   > Note: Creating JsonSchemas synchronously implies access to all $refs within the root schema. If you don't have access to all this data at the time of the construction, see "Asynchronous Creation" examples below.
-
-
-#### Example
-
-A schema can be created with a Map that is either hand-crafted, referenced from a JSON file, or *previously* fetched from the network or file system.
 
 ```dart
 import 'package:json_schema/json_schema.dart';
@@ -38,314 +31,59 @@ main() {
   final str = 'hi';
 
   // Construct the schema from the schema map or JSON string.
-  final schema = JsonSchema.createSchema(mustBeIntegerSchemaMap);
+  final schema = JsonSchema.create(mustBeIntegerSchemaMap);
 
   print('$n => ${schema.validate(n)}'); // true
   print('$decimals => ${schema.validate(decimals)}'); // false
   print('$str => ${schema.validate(str)}'); // false
 }
 ```
+
+Or see [json_schema/example/readme/synchronous_creation/self_contained.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/synchronous_creation/self_contained.dart)
+
+And run `dart run ./example/readme/synchronous_creation/self_contained.dart`
+
+
+## Advanced Usage
 
 ### Synchronous Creation, Local Ref Cache
 
 If you want to create `JsonSchema`s synchronously, and you have $refs that cannot be resolved within the root schema, but you have a cache of those $ref'd schemas locally, you can write a `RefProvider` to get them during schema evaluation.
 
-#### Example
+See [json_schema/example/readme/synchronous_creation/local_ref_cache.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/synchronous_creation/local_ref_cache.dart)
 
-```dart 
-import 'package:json_schema/json_schema.dart';
-import 'package:dart2_constant/convert.dart';
+Or run `dart run ./example/readme/synchronous_creation/local_ref_cache.dart`
 
-main() {
-  final referencedSchema = {
-    r"$id": "https://example.com/geographical-location.schema.json",
-    r"$schema": "http://json-schema.org/draft-06/schema#",
-    "title": "Longitude and Latitude",
-    "description": "A geographical coordinate on a planet (most commonly Earth).",
-    "required": ["latitude", "longitude"],
-    "type": "object",
-    "properties": {
-      "name": {"type": "string"},
-      "latitude": {"type": "number", "minimum": -90, "maximum": 90},
-      "longitude": {"type": "number", "minimum": -180, "maximum": 180}
-    }
-  };
-
-  final RefProvider refProvider = RefProvider.syncSchema((String ref) {
-    final Map references = {
-      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
-    };
-
-    if (references.containsKey(ref)) {
-      return references[ref];
-    }
-
-    return null;
-  });
-
-  final schema = JsonSchema.createSchema({
-    'type': 'array',
-    'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
-  }, refProvider: refProvider);
-
-  final workivaLocations = [
-    {
-      'name': 'Ames',
-      'latitude': 41.9956731,
-      'longitude': -93.6403663,
-    },
-    {
-      'name': 'Scottsdale',
-      'latitude': 33.4634707,
-      'longitude': -111.9266617,
-    }
-  ];
-
-  final badLocations = [
-    {
-      'name': 'Bad Badlands',
-      'latitude': 181,
-      'longitude': 92,
-    },
-    {
-      'name': 'Nowhereville',
-      'latitude': -2000,
-      'longitude': 7836,
-    }
-  ];
-
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
-}
-```
 
 ### Asynchronous Creation, Remote HTTP Refs
 
-If you have schemas that have nested $refs that are HTTP URIs that are publicly accessible, you can use `Future<JsonSchema> JsonSchema.createSchemaAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createSchemaFromUrl` if you want to fetch the root schema remotely as well (see next example).
+If you have schemas that have nested $refs that are HTTP URIs that are publicly accessible, you can use `Future<JsonSchema> JsonSchema.createAsync` and the references will be fetched as needed during evaluation. You can also use `JsonSchema.createFromUrl` if you want to fetch the root schema remotely as well (see next example).
 
-#### Example
+See [json_schema/example/readme/asynchronous_creation/remote_http_refs.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/asynchronous_creation/remote_http_refs.dart)
 
-```dart
-import 'dart:io';
-
-import 'package:json_schema/json_schema.dart';
-
-// For VM:
-import 'package:json_schema/vm.dart';
-
-// For Browser:
-// import 'package:json_schema/browser.dart';
-
-main() async {
-  // For VM:
-  configureJsonSchemaForVm();
-
-  // For Browser:
-  // configureJsonSchemaForBrowser();
-
-  // Schema Defined as a JSON String
-  final schema = await JsonSchema.createSchemaAsync(r'''
-  {
-    "type": "array",
-    "items": {
-      "$ref": "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json"
-    }
-  }
-  ''');
-
-  // Create some examples to validate against the schema.
-  final numbersArray = [1, 2, 3];
-  final decimalsArray = [3.14, 1.2, 5.8];
-  final strArray = ['hello', 'world'];
-
-  print('$numbersArray => ${schema.validate(numbersArray)}'); // true
-  print('$decimalsArray => ${schema.validate(decimalsArray)}'); // false
-  print('$strArray => ${schema.validate(strArray)}'); // false
-
-  // Exit the process cleanly (VM Only).
-  exit(0);
-}
-```
+Or run `dart run ./example/readme/asynchronous_creation/remote_http_refs.dart`
 
 ### Asynchronous Creation, From URL or File
 
-You can also create a schema directly from a publicly accessible URL, like so:
+You can also create a schema directly from a publicly accessible URL or File.
 
-#### Example 1 - URL
+#### URLs
+See [json_schema/example/readme/asynchronous_creation/from_url.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/asynchronous_creation/from_url.dart)
 
-```dart
-import 'dart:io';
+Or run `dart run ./example/readme/asynchronous_creation/from_url.dart`
 
-import 'package:json_schema/json_schema.dart';
+#### Files
+See [json_schema/example/readme/asynchronous_creation/from_file.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/asynchronous_creation/from_file.dart)
 
-// For VM:
-import 'package:json_schema/vm.dart';
-
-// For Browser:
-// import 'package:json_schema/browser.dart';
-
-main() async {
-  // For VM:
-  configureJsonSchemaForVm();
-
-  // For Browser:
-  // configureJsonSchemaForBrowser();
-
-  final url = "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json";
-
-  final schema = await JsonSchema.createSchemaFromUrl(url);
-
-  // Create some examples to validate against the schema.
-  final n = 3;
-  final decimals = 3.14;
-  final str = 'hi';
-
-  print('$n => ${schema.validate(n)}'); // true
-  print('$decimals => ${schema.validate(decimals)}'); // false
-  print('$str => ${schema.validate(str)}'); // false
-
-  // Exit the process cleanly (VM Only).
-  exit(0);
-}
-```
-
-#### Example 2 - File
-
-```dart
-import 'dart:io';
-
-import 'package:json_schema/json_schema.dart';
-
-// For VM:
-import 'package:json_schema/vm.dart';
-
-// For Browser:
-// import 'package:json_schema/browser.dart';
-
-main() async {
-  // For VM:
-  configureJsonSchemaForVm();
-
-  // For Browser:
-  // configureJsonSchemaForBrowser();
-
-  final file = "example/readme/asynchronous_creation/geo.schema.json";
-
-  final schema = await JsonSchema.createSchemaFromUrl(file);
-
-  // Create some examples to validate against the schema.
-  final workivaAmes = {
-    'latitude': 41.9956731,
-    'longitude': -93.6403663,
-  };
-
-  final nowhereville = {
-    'latitude': -2000,
-    'longitude': 7836,
-  };
-
-  print('$workivaAmes => ${schema.validate(workivaAmes)}'); // true
-  print('$nowhereville => ${schema.validate(nowhereville)}'); // false
-
-  // Exit the process cleanly (VM Only).
-  exit(0);
-}
-```
+Or run `dart run ./example/readme/asynchronous_creation/from_file.dart`
 
 ### Asynchronous Creation, with custom remote $refs:
 
-If you have nested $refs that are either non-HTTP URIs or non-publicly-accessible HTTP $refs, you can supply an async `RefProvider` to `createSchemaAsync`, and perform any custom logic you need.
+If you have nested $refs that are either non-HTTP URIs or non-publicly-accessible HTTP $refs, you can supply an async `RefProvider` to `createAsync`, and perform any custom logic you need.
 
-#### Example
+See [json_schema/example/readme/asynchronous_creation/remote_ref_cache.dart](https://github.com/Workiva/json_schema/blob/master/example/readme/asynchronous_creation/remote_ref_cache.dart)
 
-```dart
-import 'dart:io';
-import 'dart:async';
-import 'package:dart2_constant/convert.dart';
-
-import 'package:json_schema/json_schema.dart';
-
-// For VM:
-import 'package:json_schema/vm.dart';
-
-// For Browser:
-// import 'package:json_schema/browser.dart';
-
-main() async {
-  // For VM:
-  configureJsonSchemaForVm();
-
-  // For Browser:
-  // configureJsonSchemaForBrowser();
-
-  final referencedSchema = {
-    r"$id": "https://example.com/geographical-location.schema.json",
-    r"$schema": "http://json-schema.org/draft-06/schema#",
-    "title": "Longitude and Latitude",
-    "description": "A geographical coordinate on a planet (most commonly Earth).",
-    "required": ["latitude", "longitude"],
-    "type": "object",
-    "properties": {
-      "name": {"type": "string"},
-      "latitude": {"type": "number", "minimum": -90, "maximum": 90},
-      "longitude": {"type": "number", "minimum": -180, "maximum": 180}
-    }
-  };
-
-  final RefProvider refProvider = RefProvider.asyncSchema((String ref) async {
-    final Map references = {
-      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
-    };
-
-    if (references.containsKey(ref)) {
-      // Silly example that adds a 1 second delay.
-      // In practice, you could make any service call here,
-      // parse the results into a schema, and return.
-      await new Future.delayed(new Duration(seconds: 1));
-      return references[ref];
-    }
-
-    // Fall back to default URL $ref behavior
-    return await JsonSchema.createSchemaFromUrl(ref);
-  });
-
-  final schema = await JsonSchema.createSchemaAsync({
-    'type': 'array',
-    'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
-  }, refProvider: refProvider);
-
-  final workivaLocations = [
-    {
-      'name': 'Ames',
-      'latitude': 41.9956731,
-      'longitude': -93.6403663,
-    },
-    {
-      'name': 'Scottsdale',
-      'latitude': 33.4634707,
-      'longitude': -111.9266617,
-    }
-  ];
-
-  final badLocations = [
-    {
-      'name': 'Bad Badlands',
-      'latitude': 181,
-      'longitude': 92,
-    },
-    {
-      'name': 'Nowhereville',
-      'latitude': -2000,
-      'longitude': 7836,
-    }
-  ];
-
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
-
-  exit(0);
-}
-```
+Or run `dart run ./example/readme/asynchronous_creation/remote_ref_cache.dart`
 
 ## How To Use Schema Information
 
@@ -405,8 +143,8 @@ main() async {
 
   And the generated image is:
 
-  ![Grades!](https://raw.github.com/patefacio/json_schema/master/example/from_url/grades_schema.png)  
+  ![Grades!](https://raw.github.com/Workiva/json_schema/master/example/from_url/grades_schema.png)  
 
   For more detailed image open link:
-  <a href="https://raw.github.com/patefacio/json_schema/master/example/from_url/grades_schema.png"
+  <a href="https://raw.github.com/Workiva/json_schema/master/example/from_url/grades_schema.png"
   target="_blank">Grade example schema diagram</a>

--- a/bin/gensamples.dart
+++ b/bin/gensamples.dart
@@ -51,7 +51,7 @@ main() {
     final dotFilename = join(outPath, '$base.dot');
     final pngOut = join(outPath, '$base.png');
 
-    JsonSchema.createSchemaFromUrl(fname).then((schema) {
+    JsonSchema.createFromUrl(fname).then((schema) {
       schema.refMap.forEach((key, ref) => print('$key : $ref'));
       File(dotFilename).writeAsStringSync(createDot(schema));
     }).then((_) {

--- a/bin/schemadot.dart
+++ b/bin/schemadot.dart
@@ -171,7 +171,7 @@ main(List<String> args) {
   }
 
   completer.future.then((schemaText) {
-    final Future schema = JsonSchema.createSchemaAsync(json.decode(schemaText));
+    final Future schema = JsonSchema.createAsync(json.decode(schemaText));
     schema.then((schema) {
       final String dot = createDot(schema);
       if (options['out-file'] != null) {

--- a/example/from_json/movie_sample.dart
+++ b/example/from_json/movie_sample.dart
@@ -81,7 +81,7 @@ main() {
     }
   };
 
-  JsonSchema.createSchemaAsync(movieSchema).then((schema) {
+  JsonSchema.createAsync(movieSchema).then((schema) {
     final validator = Validator(schema);
     final bool validates = validator.validate(movies);
     if (!validates) {

--- a/example/from_json/validate_json_from_data.dart
+++ b/example/from_json/validate_json_from_data.dart
@@ -53,7 +53,7 @@ main() {
   final decimals = 3.14;
   final str = 'hi';
 
-  JsonSchema.createSchemaAsync(mustBeIntegerSchema).then((schema) {
+  JsonSchema.createAsync(mustBeIntegerSchema).then((schema) {
     print('$n => ${schema.validate(n)}');
     print('$decimals => ${schema.validate(decimals)}');
     print('$str => ${schema.validate(str)}');

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -50,7 +50,7 @@ main() {
   // Pull in schema from web
   //////////////////////////////////////////////////////////////////////
   String url = 'http://json-schema.org/draft-04/schema';
-  JsonSchema.createSchemaFromUrl(url).then((JsonSchema schema) {
+  JsonSchema.createFromUrl(url).then((JsonSchema schema) {
     final validSchema = {'type': 'integer'};
     print('''Does schema validate valid schema $validSchema?
   ${schema.validate(validSchema)}''');
@@ -64,7 +64,7 @@ main() {
   // Pull in schema from file in current directory
   //////////////////////////////////////////////////////////////////////
   url = 'grades_schema.json';
-  JsonSchema.createSchemaFromUrl(url).then((schema) {
+  JsonSchema.createFromUrl(url).then((schema) {
     final grades = json.decode('''
 {
     'semesters': [

--- a/example/readme/asynchronous_creation/from_file.dart
+++ b/example/readme/asynchronous_creation/from_file.dart
@@ -44,7 +44,7 @@ import 'package:json_schema/json_schema.dart';
 main() async {
   final file = "example/readme/asynchronous_creation/geo.schema.json";
 
-  final schema = await JsonSchema.createSchemaFromUrl(file);
+  final schema = await JsonSchema.createFromUrl(file);
 
   // Create some examples to validate against the schema.
   final workivaAmes = {

--- a/example/readme/asynchronous_creation/from_url.dart
+++ b/example/readme/asynchronous_creation/from_url.dart
@@ -44,7 +44,7 @@ import 'package:json_schema/json_schema.dart';
 main() async {
   final url = "https://raw.githubusercontent.com/json-schema-org/JSON-Schema-Test-Suite/master/remotes/integer.json";
 
-  final schema = await JsonSchema.createSchemaFromUrl(url);
+  final schema = await JsonSchema.createFromUrl(url);
 
   // Create some examples to validate against the schema.
   final n = 3;

--- a/example/readme/asynchronous_creation/remote_http_refs.dart
+++ b/example/readme/asynchronous_creation/remote_http_refs.dart
@@ -43,7 +43,7 @@ import 'package:json_schema/json_schema.dart';
 
 main() async {
   // Schema Defined as a JSON String
-  final schema = await JsonSchema.createSchemaAsync(r'''
+  final schema = await JsonSchema.createAsync(r'''
   {
     "type": "array",
     "items": {

--- a/example/readme/asynchronous_creation/remote_ref_cache.dart
+++ b/example/readme/asynchronous_creation/remote_ref_cache.dart
@@ -58,9 +58,9 @@ main() async {
     }
   };
 
-  final RefProvider refProvider = RefProvider.asyncSchema((String ref) async {
+  final RefProvider refProvider = RefProvider.async((String ref) async {
     final Map references = {
-      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
+      'https://example.com/geographical-location.schema.json': referencedSchema,
     };
 
     if (references.containsKey(ref)) {
@@ -71,11 +71,10 @@ main() async {
       return references[ref];
     }
 
-    // Fall back to default URL $ref behavior
-    return await JsonSchema.createSchemaFromUrl(ref);
+    return null;
   });
 
-  final schema = await JsonSchema.createSchemaAsync({
+  final schema = await JsonSchema.createAsync({
     'type': 'array',
     'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
   }, refProvider: refProvider);

--- a/example/readme/synchronous_creation/local_ref_cache.dart
+++ b/example/readme/synchronous_creation/local_ref_cache.dart
@@ -56,9 +56,9 @@ main() {
     }
   };
 
-  final RefProvider refProvider = RefProvider.syncSchema((String ref) {
+  final RefProvider refProvider = RefProvider.sync((String ref) {
     final Map references = {
-      'https://example.com/geographical-location.schema.json': JsonSchema.createSchema(referencedSchema),
+      'https://example.com/geographical-location.schema.json': referencedSchema,
     };
 
     if (references.containsKey(ref)) {
@@ -68,7 +68,7 @@ main() {
     return null;
   });
 
-  final schema = JsonSchema.createSchema({
+  final schema = JsonSchema.create({
     'type': 'array',
     'items': {r'$ref': 'https://example.com/geographical-location.schema.json'}
   }, refProvider: refProvider);

--- a/example/readme/synchronous_creation/self_contained.dart
+++ b/example/readme/synchronous_creation/self_contained.dart
@@ -49,7 +49,7 @@ main() {
   final str = 'hi';
 
   // Construct the schema from the schema map or JSON string.
-  final schema = JsonSchema.createSchema(mustBeIntegerSchemaMap);
+  final schema = JsonSchema.create(mustBeIntegerSchemaMap);
 
   print('$n => ${schema.validate(n)}'); // true
   print('$decimals => ${schema.validate(decimals)}'); // false

--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -42,9 +42,9 @@ import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/schema_url_client/html_schema_url_client.dart';
 
 @Deprecated(
-    'The library now automatically configures based on available libraries, use JsonSchema.createSchemaFromUrl instead.')
+    'The library now automatically configures based on available libraries, use JsonSchema.createFromUrl instead.')
 Future<JsonSchema> createSchemaFromUrlBrowser(String schemaUrl, {SchemaVersion schemaVersion}) =>
-    HtmlSchemaUrlClient().createSchemaFromUrl(schemaUrl, schemaVersion: schemaVersion);
+    HtmlSchemaUrlClient().createFromUrl(schemaUrl, schemaVersion: schemaVersion);
 
 /// Configures json_schema for use in the browser via dart:html.
 @Deprecated('The library now automatically configures based on available libraries, this is a no-op.')

--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -40,4 +40,4 @@ export 'package:json_schema/src/json_schema/json_schema.dart' show JsonSchema;
 export 'package:json_schema/src/json_schema/constants.dart' show SchemaVersion;
 export 'package:json_schema/src/json_schema/schema_type.dart' show SchemaType;
 export 'package:json_schema/src/json_schema/validator.dart' show Validator, ValidationError;
-export 'package:json_schema/src/json_schema/ref_provider.dart' show RefProvider;
+export 'package:json_schema/src/json_schema/ref_provider.dart' show RefProvider, defaultHttpRefProvider;

--- a/lib/json_schema.dart
+++ b/lib/json_schema.dart
@@ -40,4 +40,4 @@ export 'package:json_schema/src/json_schema/json_schema.dart' show JsonSchema;
 export 'package:json_schema/src/json_schema/constants.dart' show SchemaVersion;
 export 'package:json_schema/src/json_schema/schema_type.dart' show SchemaType;
 export 'package:json_schema/src/json_schema/validator.dart' show Validator, ValidationError;
-export 'package:json_schema/src/json_schema/ref_provider.dart' show RefProvider, defaultHttpRefProvider;
+export 'package:json_schema/src/json_schema/ref_provider.dart' show RefProvider, defaultUrlRefProvider;

--- a/lib/src/json_schema/global_platform_functions.dart
+++ b/lib/src/json_schema/global_platform_functions.dart
@@ -48,8 +48,8 @@ import 'package:json_schema/src/json_schema/schema_url_client/stub_schema_url_cl
 /// explicitly given a [JsonSchema] instance upon construction will
 /// inherit this global one.
 @Deprecated(
-    'The library now automatically configures based on available libraries, use JsonSchema.createSchemaFromUrl instead.')
-CreateJsonSchemaFromUrl get globalCreateJsonSchemaFromUrl => createClient()?.createSchemaFromUrl;
+    'The library now automatically configures based on available libraries, use JsonSchema.createFromUrl instead.')
+CreateJsonSchemaFromUrl get globalCreateJsonSchemaFromUrl => createClient()?.createFromUrl;
 
 @Deprecated('The library now automatically configures based on available libraries, this is a no-op.')
 set globalCreateJsonSchemaFromUrl(CreateJsonSchemaFromUrl createJsonSchemaFromUrl) {}

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -99,15 +99,15 @@ class JsonSchema {
 
   /// Create a schema from a JSON [data].
   ///
-  /// This method is asynchronous to support automatic fetching of sub-[JsonSchema]s for items,
+  /// This method is asynchronous to support fetching of sub-[JsonSchema]s for items,
   /// properties, and sub-properties of the root schema.
   ///
-  /// If you want to create a [JsonSchema] synchronously, use [createSchema]. Note that for
-  /// [createSchema] remote reference fetching is not supported.
+  /// If you want to create a [JsonSchema] synchronously, use [create]. Note that for
+  /// [create] remote reference fetching is not supported.
   ///
   /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec),
   /// or alternatively, a [String] may be passed in and JSON decoding will be handled automatically.
-  static Future<JsonSchema> createSchemaAsync(dynamic schema,
+  static Future<JsonSchema> createAsync(dynamic schema,
       {SchemaVersion schemaVersion, Uri fetchedFromUri, RefProvider refProvider}) {
     // Default to assuming the schema is already a decoded, primitive dart object.
     dynamic data = schema;
@@ -118,7 +118,7 @@ class JsonSchema {
       try {
         data = json.decode(schema);
       } catch (e) {
-        throw ArgumentError('String data provided to createSchemaAsync is not valid JSON.');
+        throw ArgumentError('String data provided to createAsync is not valid JSON.');
       }
     }
 
@@ -137,17 +137,26 @@ class JsonSchema {
           .future;
     }
     throw ArgumentError(
-        'Data provided to createSchemaAsync is not valid: Data must be, or parse to a Map (or bool in draft6 or later). | $data');
+        'Data provided to createAsync is not valid: Data must be, or parse to a Map (or bool in draft6 or later). | $data');
   }
+
+  @Deprecated('Use JsonSchema.createAsync instead')
+  static Future<JsonSchema> createSchemaAsync(
+    dynamic schema, {
+    SchemaVersion schemaVersion,
+    Uri fetchedFromUri,
+    RefProvider refProvider,
+  }) =>
+      createAsync(schema, schemaVersion: schemaVersion, fetchedFromUri: fetchedFromUri, refProvider: refProvider);
 
   /// Create a schema from JSON [data].
   ///
   /// This method is synchronous, and doesn't support fetching of remote references, properties, and sub-properties of the
-  /// schema. If you need remote reference support use [createSchemaAsync].
+  /// schema. If you need remote reference support use [createAsync].
   ///
   /// The [schema] can either be a decoded JSON object (Only [Map] or [bool] per the spec),
   /// or alternatively, a [String] may be passed in and JSON decoding will be handled automatically.
-  static JsonSchema createSchema(
+  static JsonSchema create(
     dynamic schema, {
     SchemaVersion schemaVersion,
     Uri fetchedFromUri,
@@ -162,7 +171,7 @@ class JsonSchema {
       try {
         data = json.decode(schema);
       } catch (e) {
-        throw ArgumentError('String data provided to createSchema is not valid JSON.');
+        throw ArgumentError('String data provided to create is not valid JSON.');
       }
     }
 
@@ -189,16 +198,29 @@ class JsonSchema {
       );
     }
     throw ArgumentError(
-        'Data provided to createSchema is not valid: Data must be a Map or a String that parses to a Map (or bool in draft6 or later). | $data');
+        'Data provided to JsonSchema.create is not valid: Data must be a Map or a String that parses to a Map (or bool in draft6 or later). | $data');
   }
+
+  @Deprecated('Use JsonSchema.create instead')
+  static JsonSchema createSchema(
+    dynamic schema, {
+    SchemaVersion schemaVersion,
+    Uri fetchedFromUri,
+    RefProvider refProvider,
+  }) =>
+      create(schema, schemaVersion: schemaVersion, fetchedFromUri: fetchedFromUri, refProvider: refProvider);
 
   /// Create a schema from a URL.
   ///
   /// This method is asyncronous to support automatic fetching of sub-[JsonSchema]s for items,
   /// properties, and sub-properties of the root schema.
-  static Future<JsonSchema> createSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) {
-    return createClient()?.createSchemaFromUrl(schemaUrl, schemaVersion: schemaVersion);
+  static Future<JsonSchema> createFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) {
+    return createClient()?.createFromUrl(schemaUrl, schemaVersion: schemaVersion);
   }
+
+  @Deprecated('Use JsonSchema.createFromUrl instead.')
+  static Future<JsonSchema> createSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) =>
+      createFromUrl(schemaUrl, schemaVersion: schemaVersion);
 
   /// Construct and validate a JsonSchema.
   _initialize({
@@ -328,7 +350,7 @@ class JsonSchema {
             localSchema = _refMap[baseUriString];
           } else if (baseUriString != null && SchemaVersion.fromString(baseUriString) != null) {
             // If the referenced URI is or within versioned schema spec.
-            localSchema = JsonSchema.createSchema(getJsonSchemaDefinitionByRef(baseUriString));
+            localSchema = JsonSchema.create(getJsonSchemaDefinitionByRef(baseUriString));
             _addSchemaToRefMap(baseUriString, localSchema);
           } else {
             // The remote ref needs to be resolved if the above checks failed.
@@ -573,7 +595,7 @@ class JsonSchema {
     return _createAndResolveProvidedSchema(ref, schemaDefinition);
   }
 
-  Future<JsonSchema> _fetchRefSchemaFromAsyncProvider(Uri ref) async {
+  Future<JsonSchema> _fetchRefSchemaFromAsyncProvider(Uri ref, {RefProvider refProvider}) async {
     // Always check refMap first.
     if (_refMap.containsKey(ref.toString())) {
       return _refMap[ref.toString()];
@@ -581,11 +603,13 @@ class JsonSchema {
 
     final Uri baseUri = ref.removeFragment();
 
+    refProvider ??= _refProvider;
+
     // Fallback order for ref provider:
     // 1. Base URI (example: localhost:1234/integer.json)
     // 2. Base URI with empty fragment (example: localhost:1234/integer.json#)
     final dynamic schemaDefinition =
-        await _refProvider.provide(baseUri.toString()) ?? await _refProvider.provide('${baseUri}#');
+        await refProvider.provide(baseUri.toString()) ?? await refProvider.provide('${baseUri}#');
 
     return _createAndResolveProvidedSchema(ref, schemaDefinition);
   }
@@ -849,6 +873,7 @@ class JsonSchema {
   ///
   /// If [isSync] is true, the provider will be used to fetch remote refs.
   /// If [isSync] is false, the provider will be used if specified, otherwise the default HTTP(S) ref provider will be used.
+  // ignore: deprecated_member_use_from_same_package
   /// If provider type is [RefProviderType.schema], fully resolved + validated schemas are expected from the provider.
   /// If provider type is [RefProviderType.json], the provider expects valid JSON objects from the provider.
   RefProvider _refProvider;
@@ -1363,7 +1388,7 @@ class JsonSchema {
 
     final AsyncRetrievalOperation asyncRefSchemaOperation = _refProvider != null
         ? () => _fetchRefSchemaFromAsyncProvider(ref).then(addSchemaFunction)
-        : () => createSchemaFromUrl(ref.toString()).then(addSchemaFunction);
+        : () => _fetchRefSchemaFromAsyncProvider(ref, refProvider: defaultHttpRefProvider).then(addSchemaFunction);
 
     final SyncRetrievalOperation syncRefSchemaOperation =
         _refProvider != null ? () => addSchemaFunction(_fetchRefSchemaFromSyncProvider(ref)) : null;

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1388,7 +1388,7 @@ class JsonSchema {
 
     final AsyncRetrievalOperation asyncRefSchemaOperation = _refProvider != null
         ? () => _fetchRefSchemaFromAsyncProvider(ref).then(addSchemaFunction)
-        : () => _fetchRefSchemaFromAsyncProvider(ref, refProvider: defaultHttpRefProvider).then(addSchemaFunction);
+        : () => _fetchRefSchemaFromAsyncProvider(ref, refProvider: defaultUrlRefProvider).then(addSchemaFunction);
 
     final SyncRetrievalOperation syncRefSchemaOperation =
         _refProvider != null ? () => addSchemaFunction(_fetchRefSchemaFromSyncProvider(ref)) : null;

--- a/lib/src/json_schema/jsonata
+++ b/lib/src/json_schema/jsonata
@@ -1,0 +1,9 @@
+//JSONata
+definitions.*.properties.*[type='boolean' or type='string' or type='number' or type='integer'].{
+   'title': title,
+   'description': description,
+   'anyOf': [
+       $.$sift(function($v, $k) {$k ~> /^(?!title$|description$).*/}),
+       {'$ref': '#/definitions/expression'}
+   ]
+}

--- a/lib/src/json_schema/jsonata
+++ b/lib/src/json_schema/jsonata
@@ -1,9 +1,0 @@
-//JSONata
-definitions.*.properties.*[type='boolean' or type='string' or type='number' or type='integer'].{
-   'title': title,
-   'description': description,
-   'anyOf': [
-       $.$sift(function($v, $k) {$k ~> /^(?!title$|description$).*/}),
-       {'$ref': '#/definitions/expression'}
-   ]
-}

--- a/lib/src/json_schema/ref_provider.dart
+++ b/lib/src/json_schema/ref_provider.dart
@@ -104,6 +104,6 @@ class RefProvider<T> {
   final T provide;
 }
 
-final defaultHttpRefProvider = RefProvider.async((String ref) async {
+final defaultUrlRefProvider = RefProvider.async((String ref) async {
   return await createClient()?.getSchemaJsonFromUrl(ref);
 });

--- a/lib/src/json_schema/ref_provider.dart
+++ b/lib/src/json_schema/ref_provider.dart
@@ -36,7 +36,10 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-import '../../json_schema.dart';
+import 'package:json_schema/json_schema.dart';
+import 'package:json_schema/src/json_schema/schema_url_client/stub_schema_url_client.dart'
+    if (dart.library.html) 'package:json_schema/src/json_schema/schema_url_client/html_schema_url_client.dart'
+    if (dart.library.io) 'package:json_schema/src/json_schema/schema_url_client/io_schema_url_client.dart';
 
 typedef SyncSchemaProvider = JsonSchema Function(String ref);
 typedef SyncJsonProvider = Map<String, dynamic> Function(String ref);
@@ -44,6 +47,7 @@ typedef AsyncJsonProvider = Future<Map<String, dynamic>> Function(String ref);
 typedef AsyncSchemaProvider = Future<JsonSchema> Function(String ref);
 
 enum RefProviderType {
+  @Deprecated('Use RefProviderType.json instead, renamed with deprecation of JsonSchema RefProviders.')
   schema,
   json,
 }
@@ -51,6 +55,7 @@ enum RefProviderType {
 class RefProvider<T> {
   RefProvider(this.provide, this.type, this.isSync);
 
+  @Deprecated('Use RefProvider.sync instead, it can resolve nested schema references more effectively.')
   static RefProvider syncSchema(SyncSchemaProvider provider) {
     return RefProvider<SyncSchemaProvider>(
       provider,
@@ -59,6 +64,7 @@ class RefProvider<T> {
     );
   }
 
+  @Deprecated('Use RefProvider.async instead, it can resolve nested schema references more effectively.')
   static RefProvider asyncSchema(AsyncSchemaProvider provider) {
     return RefProvider<AsyncSchemaProvider>(
       provider,
@@ -67,15 +73,17 @@ class RefProvider<T> {
     );
   }
 
+  @Deprecated('Use RefProvider.sync instead, renamed with deprecation of JsonSchema RefProviders.')
   static RefProvider syncJson(SyncJsonProvider provider) {
-    return RefProvider<SyncJsonProvider>(
-      provider,
-      RefProviderType.json,
-      true,
-    );
+    return RefProvider.sync(provider);
   }
 
+  @Deprecated('Use RefProvider.sync instead, renamed with deprecation of JsonSchema RefProviders.')
   static RefProvider asyncJson(AsyncJsonProvider provider) {
+    return RefProvider.async(provider);
+  }
+
+  static RefProvider async(AsyncJsonProvider provider) {
     return RefProvider<AsyncJsonProvider>(
       provider,
       RefProviderType.json,
@@ -83,7 +91,19 @@ class RefProvider<T> {
     );
   }
 
+  static RefProvider sync(SyncJsonProvider provider) {
+    return RefProvider<SyncJsonProvider>(
+      provider,
+      RefProviderType.json,
+      true,
+    );
+  }
+
   final bool isSync;
   final RefProviderType type;
   final T provide;
 }
+
+final defaultHttpRefProvider = RefProvider.async((String ref) async {
+  return await createClient()?.getSchemaJsonFromUrl(ref);
+});

--- a/lib/src/json_schema/schema_url_client/html_schema_url_client.dart
+++ b/lib/src/json_schema/schema_url_client/html_schema_url_client.dart
@@ -6,10 +6,11 @@ import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/schema_url_client/schema_url_client.dart';
 import 'package:json_schema/src/json_schema/utils.dart';
+import 'package:rfc_6901/rfc_6901.dart';
 
 class HtmlSchemaUrlClient extends SchemaUrlClient {
   @override
-  createSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) async {
+  createFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) async {
     final uriWithFrag = Uri.parse(schemaUrl);
     var uri = uriWithFrag.removeFragment();
     if (schemaUrl.endsWith('#')) {
@@ -30,9 +31,42 @@ class HtmlSchemaUrlClient extends SchemaUrlClient {
 
       // HTTP servers ignore fragments, so resolve a sub-map if a fragment was specified.
       final parentSchema =
-          await JsonSchema.createSchemaAsync(jsonResponse, schemaVersion: schemaVersion, fetchedFromUri: uri);
+          await JsonSchema.createAsync(jsonResponse, schemaVersion: schemaVersion, fetchedFromUri: uri);
       final schema = JsonSchemaUtils.getSubMapFromFragment(parentSchema, uriWithFrag);
       return schema ?? parentSchema;
+    } else {
+      throw FormatException('Url schema must be http: $schemaUrl. To use a local file, use dart:io');
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>> getSchemaJsonFromUrl(String schemaUrl) async {
+    final uriWithFrag = Uri.parse(schemaUrl);
+    var uri = uriWithFrag.removeFragment();
+    if (schemaUrl.endsWith('#')) {
+      uri = uriWithFrag;
+    }
+    if (uri.scheme != 'file') {
+      // _logger.info('Getting url $uri'); TODO: re-add logger.
+      final response = await http.get(uri);
+
+      var jsonResponse;
+      if (response.statusCode == 200) {
+        jsonResponse = json.decode(response.body);
+      } else {
+        // If the server did not return a 200 OK response,
+        // then throw an exception.
+        throw Exception('Failed to load Schema from: $uri');
+      }
+
+      // HTTP servers ignore fragments, so resolve a sub-map if a fragment was specified.
+      var subSchema;
+      try {
+        subSchema = JsonPointer(uriWithFrag.fragment)?.read(jsonResponse);
+      } catch (_) {
+        // Do nothing if we fail to decode or read the pointer.
+      }
+      return subSchema ?? jsonResponse;
     } else {
       throw FormatException('Url schema must be http: $schemaUrl. To use a local file, use dart:io');
     }

--- a/lib/src/json_schema/schema_url_client/io_schema_url_client.dart
+++ b/lib/src/json_schema/schema_url_client/io_schema_url_client.dart
@@ -6,10 +6,11 @@ import 'package:json_schema/src/json_schema/constants.dart';
 import 'package:json_schema/src/json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/utils.dart';
 import 'package:json_schema/src/json_schema/schema_url_client/schema_url_client.dart';
+import 'package:rfc_6901/rfc_6901.dart';
 
 class IoSchemaUrlClient extends SchemaUrlClient {
   @override
-  createSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) async {
+  createFromUrl(String schemaUrl, {SchemaVersion schemaVersion}) async {
     final uriWithFrag = Uri.parse(schemaUrl);
     final uri = schemaUrl.endsWith('#') ? uriWithFrag : uriWithFrag.removeFragment();
     Map schemaMap;
@@ -32,10 +33,42 @@ class IoSchemaUrlClient extends SchemaUrlClient {
       throw FormatException('Url schema must be http, file, or empty: $schemaUrl');
     }
     // HTTP servers / file systems ignore fragments, so resolve a sub-map if a fragment was specified.
-    final parentSchema =
-        await JsonSchema.createSchemaAsync(schemaMap, schemaVersion: schemaVersion, fetchedFromUri: uri);
+    final parentSchema = await JsonSchema.createAsync(schemaMap, schemaVersion: schemaVersion, fetchedFromUri: uri);
     final schema = JsonSchemaUtils.getSubMapFromFragment(parentSchema, uriWithFrag);
     return schema ?? parentSchema;
+  }
+
+  @override
+  Future<Map<String, dynamic>> getSchemaJsonFromUrl(String schemaUrl) async {
+    final uriWithFrag = Uri.parse(schemaUrl);
+    final uri = schemaUrl.endsWith('#') ? uriWithFrag : uriWithFrag.removeFragment();
+    Map schemaMap;
+    if (uri.scheme == 'http' || uri.scheme == 'https') {
+      // Setup the HTTP request.
+      final httpRequest = await HttpClient().getUrl(uri);
+      httpRequest.followRedirects = true;
+      // Fetch the response
+      final response = await httpRequest.close();
+      // Convert the response into a string
+      if (response.statusCode == HttpStatus.notFound) {
+        throw ArgumentError('Schema at URL: $schemaUrl can\'t be found.');
+      }
+      final schemaText = await convert.Utf8Decoder().bind(response).join();
+      schemaMap = json.decode(schemaText);
+    } else if (uri.scheme == 'file' || uri.scheme == '') {
+      final fileString = await File(uri.scheme == 'file' ? uri.toFilePath() : schemaUrl).readAsString();
+      schemaMap = json.decode(fileString);
+    } else {
+      throw FormatException('Url schema must be http, file, or empty: $schemaUrl');
+    }
+    // HTTP servers ignore fragments, so resolve a sub-map if a fragment was specified.
+    var subSchema;
+    try {
+      subSchema = JsonPointer(uriWithFrag.fragment)?.read(schemaMap);
+    } catch (_) {
+      // Do nothing if we fail to decode or read the pointer.
+    }
+    return subSchema ?? schemaMap;
   }
 }
 

--- a/lib/src/json_schema/schema_url_client/schema_url_client.dart
+++ b/lib/src/json_schema/schema_url_client/schema_url_client.dart
@@ -1,5 +1,7 @@
 import 'package:json_schema/json_schema.dart';
 
 abstract class SchemaUrlClient {
-  Future<JsonSchema> createSchemaFromUrl(String schemaUrl, {SchemaVersion schemaVersion});
+  Future<JsonSchema> createFromUrl(String schemaUrl, {SchemaVersion schemaVersion});
+
+  Future<Map<String, dynamic>> getSchemaJsonFromUrl(String schemaUrl);
 }

--- a/lib/vm.dart
+++ b/lib/vm.dart
@@ -42,9 +42,9 @@ import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/schema_url_client/io_schema_url_client.dart';
 
 @Deprecated(
-    'The library now automatically configures based on available libraries, use JsonSchema.createSchemaFromUrl instead.')
+    'The library now automatically configures based on available libraries, use JsonSchema.createFromUrl instead.')
 Future<JsonSchema> createSchemaFromUrlVm(String schemaUrl, {SchemaVersion schemaVersion}) =>
-    IoSchemaUrlClient().createSchemaFromUrl(schemaUrl, schemaVersion: schemaVersion);
+    IoSchemaUrlClient().createFromUrl(schemaUrl, schemaVersion: schemaVersion);
 
 /// Configures json_schema for use in the browser via dart:html.
 @Deprecated('The library now automatically configures based on available libraries, this is a no-op.')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Provide support for validating instances against json schema
 homepage: https://github.com/workiva/json_schema
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   args: '>=0.13.7 <3.0.0'

--- a/test/unit/json_schema/draft4_invalid_schemas_test.dart
+++ b/test/unit/json_schema/draft4_invalid_schemas_test.dart
@@ -78,7 +78,7 @@ void main([List<String> args]) {
             });
 
             try {
-              await JsonSchema.createSchemaAsync(schemaData, schemaVersion: SchemaVersion.draft4);
+              await JsonSchema.createAsync(schemaData, schemaVersion: SchemaVersion.draft4);
               fail('Schema is expected to be invalid, but was not.');
             } catch (e) {
               catchException(e);

--- a/test/unit/json_schema/schema_self_validation.dart
+++ b/test/unit/json_schema/schema_self_validation.dart
@@ -62,7 +62,7 @@ void main([List<String> args]) {
       // Pull in the official schema, verify description and then ensure
       // that the schema satisfies the schema for schemas
       final url = 'http://json-schema.org/draft-04/schema#';
-      JsonSchema.createSchemaFromUrl(url).then((schema) {
+      JsonSchema.createFromUrl(url).then((schema) {
         expect(schema.schemaMap['description'], 'Core schema meta-schema');
         expect(schema.validate(schema.schemaMap), true);
       });
@@ -71,7 +71,7 @@ void main([List<String> args]) {
       // Pull in the official schema, verify description and then ensure
       // that the schema satisfies the schema for schemas
       final url = 'http://json-schema.org/draft-06/schema#';
-      JsonSchema.createSchemaFromUrl(url).then((schema) {
+      JsonSchema.createFromUrl(url).then((schema) {
         expect(schema.schemaMap['description'], 'Core schema meta-schema');
         expect(schema.validate(schema.schemaMap), true);
       });
@@ -80,7 +80,7 @@ void main([List<String> args]) {
       // Pull in the official schema, verify description and then ensure
       // that the schema satisfies the schema for schemas
       final url = 'http://json-schema.org/draft-07/schema#';
-      JsonSchema.createSchemaFromUrl(url).then((schema) {
+      JsonSchema.createFromUrl(url).then((schema) {
         expect(schema.schemaMap['description'], 'Core schema meta-schema');
         expect(schema.validate(schema.schemaMap), true);
       });

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -5,7 +5,7 @@ import 'package:json_schema/json_schema.dart';
 import 'package:test/test.dart';
 
 JsonSchema createObjectSchema(Map<String, dynamic> nestedSchema) {
-  return JsonSchema.createSchema({
+  return JsonSchema.create({
     'properties': {'someKey': nestedSchema}
   });
 }
@@ -13,7 +13,7 @@ JsonSchema createObjectSchema(Map<String, dynamic> nestedSchema) {
 void main() {
   group('ValidationError', () {
     test('boolean false at root', () {
-      final schema = JsonSchema.createSchema(false);
+      final schema = JsonSchema.create(false);
       final errors = schema.validateWithErrors({'someKey': 1});
 
       expect(errors.length, 1);
@@ -23,7 +23,7 @@ void main() {
     });
 
     test('boolean false in object', () {
-      final schema = JsonSchema.createSchema({
+      final schema = JsonSchema.create({
         'properties': {'someKey': false}
       });
       final errors = schema.validateWithErrors({'someKey': 1});
@@ -564,7 +564,7 @@ void main() {
     });
 
     group('string formatting', () {
-      final schema = JsonSchema.createSchema({
+      final schema = JsonSchema.create({
         "properties": {
           "foo": {"type": "string"},
           "bar": {"type": "integer"}
@@ -600,15 +600,15 @@ void main() {
         }
       };
 
-      final RefProvider syncRefProvider = RefProvider.syncSchema((String ref) {
+      final RefProvider syncRefProvider = RefProvider.sync((String ref) {
         final refs = {
           'http://localhost/destination.json': {'maxLength': 2}
         };
 
-        return JsonSchema.createSchema(refs[ref]);
+        return refs[ref];
       });
 
-      final schema = JsonSchema.createSchema(schemaJson, refProvider: syncRefProvider);
+      final schema = JsonSchema.create(schemaJson, refProvider: syncRefProvider);
 
       test('local', () {
         final errors = schema.validateWithErrors({'minLength': 'foo'});


### PR DESCRIPTION
## Ultimate problem:
- `JsonSchema.createSchema` is redundant
- `JsonSchema.createSchemaAsync` is redundant
- `JsonSchema.createSchemaFromUrl` is redundant
- No default implementation of a RefProvider exists for URLs.
- `RefProvider.syncSchema` is harder to use and worse than `RefProvider.syncJson`
- `RefProvider.asyncSchema` is harder to use and worse than `RefProvider.asyncJson`

## How it was fixed:
- `JsonSchema.createSchema` --> `JsonSchema.create`
- `JsonSchema.createSchemaAsync` --> `JsonSchema.createAsync`
- `JsonSchema.createSchemaFromUrl` --> `JsonSchema.createFromUrl`
- Expose a `defaultUrlRefProvider`.
- `RefProvider.syncJson` --> `RefProvider.sync`
- `RefProvider.asyncJson` --> `RefProvider.async`
- Deprecate but allow all old factory names for `JsonSchema` and `RefProvider`
- Update all examples
- Update all usages
- Use `defaultUrlRefProvider` in `JsonSchema.createFromUrl`
- Simplify Readme

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf