### PR TITLE
imp(validator): expose two errors for missing properties, one for the root object path, as well as the property itself

### DIFF
--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -534,7 +534,10 @@ class Validator {
     if (schema.requiredProperties != null) {
       schema.requiredProperties.forEach((prop) {
         if (!instance.data.containsKey(prop)) {
+          // One error for the root object that contains the missing property.
           _err('required prop missing: ${prop} from $instance', instance.path, schema.path + '/required');
+          // Another error for the property on the root object. (Allows consumers to identify errors for individual fields)
+          _err('required prop missing: ${prop} from $instance', '${instance.path}/${prop}', schema.path + '/required');
         }
       });
     }

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -585,7 +585,7 @@ void main() {
 
       test('without an instance path should add "root" instead of the path', () {
         final errors = schema.validateWithErrors({});
-        expect(errors.length, 1);
+        expect(errors.length, 2);
         expect(errors[0].toString(), '# (root): required prop missing: foo from {}');
       });
     });

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -468,10 +468,15 @@ void main() {
         'someKey': {'foo': 'a'}
       });
 
-      expect(errors.length, 1);
+      // Error for the root object instance path.
+      expect(errors.length, 2);
       expect(errors[0].instancePath, '/someKey');
       expect(errors[0].schemaPath, '/properties/someKey/required');
       expect(errors[0].message, contains('required'));
+      // Second error for the missing property on object.
+      expect(errors[1].instancePath, '/someKey/bar');
+      expect(errors[1].schemaPath, '/properties/someKey/required');
+      expect(errors[1].message, contains('required'));
     });
 
     test('Object pattern properties', () {


### PR DESCRIPTION
## Ultimate problem:
- Consumers complain that it is difficult to tell which properties have required errors because we only expose them on the root object, and more detail would require parsing the error message.

## How it was fixed:
- Expose an additional, more specific error.

## Testing suggestions:
- Test with workflow client validation before merging.

## Potential areas of regression:


---

> __FYA:__ @michaelcarter-wf