### PR TITLE
Implement minContains and maxContains for draft 2019-09

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -796,10 +796,16 @@ class JsonSchema {
   /// [JsonSchema] definition that at least one item must match to be valid.
   JsonSchema _contains;
 
-  /// Maimum number of items allowed.
+  /// Minimum number of [_contains] required.
+  int _minContains;
+
+  /// Maximum number of [_contains] allowed
+  int _maxContains;
+
+  /// Maximum number of items allowed.
   int _maxItems;
 
-  /// Maimum number of items allowed.
+  /// Minimum number of items allowed.
   int _minItems;
 
   /// Whether the items in the list must be unique.
@@ -980,8 +986,8 @@ class JsonSchema {
 
       // Added or changed in draft2019_09: Applicator Vocabulary
       'dependentRequired': (JsonSchema s, dynamic v) => null, // TODO: implement, deprecate dependencies?
-      'maxContains': (JsonSchema s, dynamic v) => null, // TODO: implement
-      'minContains': (JsonSchema s, dynamic v) => null, // TODO: implement
+      'maxContains': (JsonSchema s, dynamic v) => s._setMaxContains(v),
+      'minContains': (JsonSchema s, dynamic v) => s._setMinContains(v),
 
       // Added or changed in draft2019_09: Format Vocabulary (TODO in other places)
 
@@ -1322,6 +1328,16 @@ class JsonSchema {
   ///
   /// Spec: https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13
   bool get uniqueItems => _uniqueItems;
+
+  /// The minimum number of elements in the list that are valid against the schema for [contains]
+  ///
+  /// https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.4.4
+  int get minContains => _minContains;
+
+  /// The maximum number of elements in the list that are valid against the schema for [contains]
+  ///
+  /// https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.4.4
+  int get maxContains => _maxContains;
 
   // --------------------------------------------------------------------------
   // Schema Sub-Property Related Getters
@@ -1788,6 +1804,12 @@ class JsonSchema {
 
   /// Validate, calculate and set the value of the 'contains' JSON Schema keyword.
   _setContains(dynamic value) => _createOrRetrieveSchema('$_path/contains', value, (rhs) => _contains = rhs);
+
+  /// Validate, calculate and set the value of the 'minContains' JSON Schema keyword.
+  _setMinContains(dynamic value) => _minContains = TypeValidators.nonNegativeInt('minContains', value);
+
+  /// Validate, calculate and set the value of the 'maxContains' JSON Schema keyword.
+  _setMaxContains(dynamic value) => _maxContains = TypeValidators.nonNegativeInt('maxContains', value);
 
   /// Validate, calculate and set the value of the 'examples' JSON Schema keyword.
   _setExamples(dynamic value) => _examples = TypeValidators.list('examples', value);

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -292,7 +292,16 @@ class Validator {
     }
 
     if (schema.contains != null) {
-      if (!instance.data.any((item) => Validator(schema.contains).validate(item))) {
+      final maxContains = schema.maxContains;
+      final minContains = schema.minContains ?? ((maxContains is int) ? 1 : null);
+      final containsItems = instance.data.where((item) => Validator(schema.contains).validate(item)).toList();
+      if (minContains is int && containsItems.length < minContains) {
+        _err('minContains violated: $instance', instance.path, schema.path);
+      }
+      if (maxContains is int && containsItems.length > maxContains) {
+        _err('maxContains violated: $instance', instance.path, schema.path);
+      }
+      if (containsItems.length == 0 && !(minContains is int && minContains == 0)) {
         _err('contains violated: $instance', instance.path, schema.path);
       }
     }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -293,7 +293,7 @@ class Validator {
 
     if (schema.contains != null) {
       final maxContains = schema.maxContains;
-      final minContains = schema.minContains ?? ((maxContains is int) ? 1 : null);
+      final minContains = schema.minContains;
       final containsItems = instance.data.where((item) => Validator(schema.contains).validate(item)).toList();
       if (minContains is int && containsItems.length < minContains) {
         _err('minContains violated: $instance', instance.path, schema.path);

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -175,8 +175,6 @@ final List<String> draft9SkippedTestFiles = [
   "items.json",
   "hostname.json",
   "json-pointer.json",
-  "maxContains.json",
-  "minContains.json",
   "not.json",
   "propertyNames.json",
   "recursiveRef.json",


### PR DESCRIPTION
## Ultimate problem:
`minContains` and `maxContains` is missing from draft 2019-09.

## How it was fixed:
Implement the missing functionality.

## Testing suggestions:
Ensure the unit tests for minContains and maxContains pass for draft 2019-09.

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf @tomdeering-wf 