### PR TITLE
Mixing JsonSchema objects to support properties along side of $refs

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1921,7 +1921,7 @@ class JsonSchema {
   _setRequiredV6(dynamic value) =>
       _requiredProperties = (TypeValidators.list('required', value))?.map((value) => value as String)?.toList();
 
-  /// Mixin a another JsonSchema into this one. All references must be resolved before calling.
+  /// Mixin another JsonSchema into this one. All references must be resolved before calling.
   mixinForRef(JsonSchema ref) {
     this._schemaMap.remove(r'$ref');
     this._ref = null;

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1925,6 +1925,7 @@ class JsonSchema {
   mixinForRef(JsonSchema ref) {
     this._schemaMap.remove(r'$ref');
     this._ref = null;
+    // The specification might be ambiguous on how to merge references into the current node. This is our best guess.
     this._schemaMap.deepMerge(ref._schemaMap);
 
     this._validateAndSetAllProperties();

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -980,10 +980,9 @@ class JsonSchema {
       // Added or changed in draft2019_09: Core Vocabulary
       r'$anchor': (JsonSchema s, dynamic v) => null, // TODO: implement
       r'$defs': (JsonSchema s, dynamic v) => s._setDefs(v),
-      r'$id': (JsonSchema s, dynamic v) => null, // TODO: change behavior
+      // r'$id': (JsonSchema s, dynamic v) => null, // TODO: change behavior
       r'$recursiveRef': (JsonSchema s, dynamic v) => null, // TODO: implement
       r'$recursiveAnchor': (JsonSchema s, dynamic v) => null, // TODO: implement
-      r'$ref': (JsonSchema s, dynamic v) => null, // TODO: change behavior
       r'$vocabulary': (JsonSchema s, dynamic v) => null, // TODO: implement
 
       // Added or changed in draft2019_09: Applicator Vocabulary
@@ -1921,4 +1920,13 @@ class JsonSchema {
   /// Validate, calculate and set the value of the 'required' JSON Schema keyword.
   _setRequiredV6(dynamic value) =>
       _requiredProperties = (TypeValidators.list('required', value))?.map((value) => value as String)?.toList();
+
+  /// Mixin a another JsonSchema into this one. All references must be resolved before calling.
+  mixinForRef(JsonSchema ref) {
+    this._schemaMap.remove(r'$ref');
+    this._ref = null;
+    this._schemaMap.deepMerge(ref._schemaMap);
+
+    this._validateAndSetAllProperties();
+  }
 }

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -111,8 +111,10 @@ extension DeepMerge<K> on Map<K, dynamic> {
   /// Merge other into this with properties in this taking precedence.
   Map<K, dynamic> deepMerge(Map<K, dynamic> other) {
     other.forEach((key, value) {
-      if (this.containsKey(key) && value is Map && this[key].runtimeType == value.runtimeType) {
-        this[key] = (this[key] as Map).deepMerge(value);
+      if (this.containsKey(key)) {
+        if (value is Map && this[key].runtimeType == value.runtimeType) {
+          this[key] = (this[key] as Map).deepMerge(value);
+        } // Else don't clobber what is is there
       } else {
         this[key] = value;
       }

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -113,7 +113,7 @@ extension DeepMerge<K> on Map<K, dynamic> {
   Map<K, dynamic> deepMerge(Map<K, dynamic> other) {
     other.forEach((key, value) {
       if (this.containsKey(key)) {
-        if (value is Map && this[key].runtimeType == value.runtimeType) {
+        if (value is Map && this[key] is Map) {
           this[key] = (this[key] as Map).deepMerge(value);
         } // Else don't clobber what is is there
       } else {

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -109,6 +109,7 @@ class DefaultValidators {
 
 extension DeepMerge<K> on Map<K, dynamic> {
   /// Merge other into this with properties in this taking precedence.
+  /// Lists ARE NOT concatenated together.
   Map<K, dynamic> deepMerge(Map<K, dynamic> other) {
     other.forEach((key, value) {
       if (this.containsKey(key)) {

--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -106,3 +106,17 @@ class DefaultValidators {
     }
   }
 }
+
+extension DeepMerge<K> on Map<K, dynamic> {
+  /// Merge other into this with properties in this taking precedence.
+  Map<K, dynamic> deepMerge(Map<K, dynamic> other) {
+    other.forEach((key, value) {
+      if (this.containsKey(key) && value is Map && this[key].runtimeType == value.runtimeType) {
+        this[key] = (this[key] as Map).deepMerge(value);
+      } else {
+        this[key] = value;
+      }
+    });
+    return this;
+  }
+}

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -148,7 +148,7 @@ class Validator {
       return instance is String;
     } else if (type == SchemaType.integer) {
       return instance is int ||
-          ([SchemaVersion.draft6, SchemaVersion.draft7].contains(schema.schemaVersion) &&
+          ([SchemaVersion.draft6, SchemaVersion.draft7, SchemaVersion.draft2019_09].contains(schema.schemaVersion) &&
               instance is num &&
               instance.remainder(1) == 0);
     } else if (type == SchemaType.number) {
@@ -580,7 +580,14 @@ class Validator {
     /// If the [JsonSchema] being validated is a ref, pull the ref
     /// from the [refMap] instead.
     while (schema.ref != null) {
-      schema = schema.resolvePath(schema.ref);
+      var nextSchema = schema.resolvePath(schema.ref);
+      if (schema.schemaVersion == SchemaVersion.draft2019_09 &&
+          schema.schemaMap.length > 1 &&
+          nextSchema.schemaBool == null) {
+        schema.mixinForRef(nextSchema);
+      } else {
+        schema = nextSchema;
+      }
     }
 
     /// If the [JsonSchema] is a bool, always return this value.

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -152,7 +152,7 @@ final List<String> commonSkippedTests = []
   ..addAll(skippedRelativeJsonPointerFormatTest)
   ..addAll(skppedIdnHostnameFormatTests);
 
-final List<String> draft9SkippedTestFiles = [
+final List<String> draft2019SkippedTestFiles = [
   "anchor.json",
   "boolean_schema.json",
   "date.json",
@@ -178,7 +178,6 @@ final List<String> draft9SkippedTestFiles = [
   "not.json",
   "propertyNames.json",
   "recursiveRef.json",
-  "ref.json",
   "refOfUnknownKeyword.json",
   "refRemote.json",
   "regex.json",
@@ -193,3 +192,9 @@ final List<String> draft9SkippedTestFiles = [
   "uuid.json",
   "vocabulary.json",
 ]..addAll(commonSkippedTestFiles);
+
+final List<String> draft2019SkippedTests = [
+  'remote ref, containing refs itself : remote ref valid',
+  'remote ref, containing refs itself : remote ref invalid',
+  'ref creates new scope when adjacent to keywords : referenced subschema doesn\'t see annotations from properties'
+]..addAll(commonSkippedTests);

--- a/test/unit/json_schema/specification_test.dart
+++ b/test/unit/json_schema/specification_test.dart
@@ -176,8 +176,8 @@ void main() {
   runAllTestsForDraftX(
     SchemaVersion.draft2019_09,
     allDraft2019,
-    draft9SkippedTestFiles,
-    commonSkippedTests,
+    draft2019SkippedTestFiles,
+    draft2019SkippedTests,
   );
 
   // Run all tests synchronously with a sync ref provider.
@@ -208,8 +208,8 @@ void main() {
   runAllTestsForDraftX(
     SchemaVersion.draft2019_09,
     allDraft2019,
-    draft9SkippedTestFiles,
-    commonSkippedTests,
+    draft2019SkippedTestFiles,
+    draft2019SkippedTests,
     isSync: true,
     refProvider: deprecatedSyncRefSchemaProvider,
   );
@@ -250,8 +250,8 @@ void main() {
   runAllTestsForDraftX(
     SchemaVersion.draft2019_09,
     allDraft2019,
-    draft9SkippedTestFiles,
-    commonSkippedTests,
+    draft2019SkippedTestFiles,
+    draft2019SkippedTests,
     isSync: true,
     refProvider: syncRefProvider,
   );
@@ -288,8 +288,8 @@ void main() {
   runAllTestsForDraftX(
     SchemaVersion.draft2019_09,
     allDraft2019,
-    draft9SkippedTestFiles,
-    commonSkippedTests,
+    draft2019SkippedTestFiles,
+    draft2019SkippedTests,
     refProvider: deprecatedAsyncRefSchemaProvider,
   );
 
@@ -325,8 +325,8 @@ void main() {
   runAllTestsForDraftX(
     SchemaVersion.draft2019_09,
     allDraft2019,
-    draft9SkippedTestFiles,
-    commonSkippedTests,
+    draft2019SkippedTestFiles,
+    draft2019SkippedTests,
     refProvider: asyncRefProvider,
   );
 }


### PR DESCRIPTION
## Ultimate problem:
Draft 2019 specifies properties can live beside `$refs`.

## How it was fixed:
When there are additional properties alongside a `$ref`, mixin the `$ref` to the current object and remove the original `$ref` annotation.

## Testing suggestions:

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf @tomdeering-wf 