### PR TITLE
Implement Draft 2019-09 format validation

### DIFF
--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -37,6 +37,15 @@
 //     THE SOFTWARE.
 
 class JsonSchemaValidationRegexes {
+  // Spec: the ISO 8601 ABNF as given in Appendix A of RFC 3339
+  // From: https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html
+  static RegExp duration = RegExp(
+      r'^P(\d{1,}W|T(\d{1,}H(\d{1,}M(\d{1,}S)?)?|\d{1,}M(\d{1,}S)?|\d{1,}S)|(\d{1,}D|\d{1,}M(\d{1,}D)?|\d{1,}Y(\d{1,}M(\d{1,}D)?)?)(T(\d{1,}H(\d{1,}M(\d{1,}S)?)?|\d{1,}M(\d{1,}S)?|\d{1,}S))?)$');
+
+  // Spec: https://datatracker.ietf.org/doc/html/rfc4122
+  static RegExp uuid =
+      RegExp(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$');
+
   // From: https://emailregex.com/ (JavaScript)
   static RegExp email = RegExp(
       r'^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
@@ -46,12 +55,23 @@ class JsonSchemaValidationRegexes {
       r'(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))\.'
       r'(\d|[1-9]\d|1\d\d|2([0-4]\d|5[0-5]))$');
 
+  // Spec: https://datatracker.ietf.org/doc/html/rfc1034
   static RegExp hostname = RegExp(r'^(?=.{1,255}$)'
       r'[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?'
       r'(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$');
 
+  // Spec: https://datatracker.ietf.org/doc/html/rfc1123
+  static RegExp hostnameDraft2019 = RegExp(r'^(?=.{1,255}$)'
+      r'[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?'
+      r'(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$');
+
   // From: https://github.com/johno/domain-regex/blob/master/index.js
+  // Spec: https://datatracker.ietf.org/doc/html/rfc1034
   static RegExp idnHostname = RegExp(r'\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b');
+
+  // Spec: https://datatracker.ietf.org/doc/html/rfc1123
+  static RegExp idnHostnameDraft2019 =
+      RegExp(r'\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b');
 
   static RegExp jsonPointer = RegExp(r'^(?:\/(?:[^~/]|~0|~1)*)*$');
 

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -101,17 +101,11 @@ class Validator {
       bool parseJson = false,
       bool validateFormats,
       bool treatWarningsAsErrors = false}) {
-    if (validateFormats == null) {
-      // Reference: https://json-schema.org/draft/2019-09/release-notes.html#format-vocabulary
-      if ([SchemaVersion.draft4, SchemaVersion.draft6, SchemaVersion.draft7].contains(_rootSchema.schemaVersion)) {
-        // By default, formats are validated on a best-effort basis from draft4 through draft7.
-        validateFormats = true;
-      } else {
-        // Starting with Draft 2019-09, formats shouldn't be validated by default.
-        validateFormats = false;
-      }
-    }
-    _validateFormats = validateFormats;
+    // Reference: https://json-schema.org/draft/2019-09/release-notes.html#format-vocabulary
+    // By default, formats are validated on a best-effort basis from draft4 through draft7.
+    // Starting with Draft 2019-09, formats shouldn't be validated by default.
+    _validateFormats =
+        validateFormats ?? _rootSchema.schemaVersion.compareTo(SchemaVersion.draft2019_09) < 0 ? true : false;
     _treatWarningsAsErrors = treatWarningsAsErrors;
 
     dynamic data = instance;
@@ -395,7 +389,7 @@ class Validator {
         final isValid = defaultValidators.uriValidator ?? (_) => false;
 
         if (!isValid(instance.data)) {
-          _err('"uri" format not accepted $instance', instance.path, schema.path);
+          _err('"iri" format not accepted $instance', instance.path, schema.path);
         }
         break;
       case 'iri-reference':
@@ -444,17 +438,29 @@ class Validator {
         try {
           Uri.parseIPv6Address(instance.data);
         } on FormatException catch (_) {
-          _err('ipv6" format not accepted $instance', instance.path, schema.path);
+          _err('"ipv6" format not accepted $instance', instance.path, schema.path);
         }
         break;
       case 'hostname':
-        if (JsonSchemaValidationRegexes.hostname.firstMatch(instance.data) == null) {
+        final regexp = schema.schemaVersion.compareTo(SchemaVersion.draft2019_09) < 0
+            ? JsonSchemaValidationRegexes.hostname
+            // Updated in Draft 2019-09
+            : JsonSchemaValidationRegexes.hostnameDraft2019;
+
+        if (regexp.firstMatch(instance.data) == null) {
           _err('"hostname" format not accepted $instance', instance.path, schema.path);
         }
         break;
       case 'idn-hostname':
-        if (SchemaVersion.draft7 != schema.schemaVersion) return;
-        if (JsonSchemaValidationRegexes.idnHostname.firstMatch(instance.data) == null) {
+        // Introduced in Draft 7
+        if (schema.schemaVersion.compareTo(SchemaVersion.draft7) < 0) return;
+
+        final regexp = schema.schemaVersion.compareTo(SchemaVersion.draft2019_09) < 0
+            ? JsonSchemaValidationRegexes.idnHostname
+            // Updated in Draft 2019-09
+            : JsonSchemaValidationRegexes.idnHostnameDraft2019;
+
+        if (regexp.firstMatch(instance.data) == null) {
           _err('"idn-hostname" format not accepted $instance', instance.path, schema.path);
         }
         break;
@@ -463,13 +469,13 @@ class Validator {
         try {
           JsonPointer(instance.data);
         } on FormatException catch (_) {
-          _err('json-pointer" format not accepted $instance', instance.path, schema.path);
+          _err('"json-pointer" format not accepted $instance', instance.path, schema.path);
         }
         break;
       case 'relative-json-pointer':
         if (SchemaVersion.draft7 != schema.schemaVersion) return;
         if (JsonSchemaValidationRegexes.relativeJsonPointer.firstMatch(instance.data) == null) {
-          _err('relative-json-pointer" format not accepted $instance', instance.path, schema.path);
+          _err('"relative-json-pointer" format not accepted $instance', instance.path, schema.path);
         }
         break;
       case 'regex':
@@ -480,6 +486,18 @@ class Validator {
           RegExp(instance.data, unicode: true);
         } catch (e) {
           _err('"regex" format not accepted $instance', instance.path, schema.path);
+        }
+        break;
+      case 'duration':
+        if (SchemaVersion.draft2019_09.compareTo(schema.schemaVersion) > 0) return;
+        if (JsonSchemaValidationRegexes.duration.firstMatch(instance.data) == null) {
+          _err('"duration" format not accepted $instance', instance.path, schema.path);
+        }
+        break;
+      case 'uuid':
+        if (SchemaVersion.draft2019_09.compareTo(schema.schemaVersion) > 0) return;
+        if (JsonSchemaValidationRegexes.uuid.firstMatch(instance.data) == null) {
+          _err('"duration" format not accepted $instance', instance.path, schema.path);
         }
         break;
       default:

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -21,7 +21,7 @@ final List<String> skippedDraft6FormatTestFiles = const [
 /// Commented out lines are NOT skipped.
 final List<String> skippedDraft7FormatTestFiles = const [
   // 'date.json',
-  'idn-email.json',
+  // 'idn-email.json',
   // 'idn-hostname.json',
   // 'iri-reference.json',
   // 'iri.json',
@@ -103,6 +103,21 @@ final List<String> skippedPermissiveDateTimeFormatTests = const [
   'validation of time strings : a valid time string with second fraction', // time.json
   'validation of time strings : a valid time string with precise second fraction', // time.json
   'validation of time strings : a valid time string with case-insensitive Z', // time.json
+  // Draft 2019 and later (date format)
+  'validation of date strings : a invalid date string with 32 days in January', // date.json
+  'validation of date strings : a invalid date string with 32 days in March', // date.json
+  'validation of date strings : a invalid date string with 32 days in May', // date.json
+  'validation of date strings : a invalid date string with 32 days in July', // date.json
+  'validation of date strings : a invalid date string with 32 days in August', // date.json
+  'validation of date strings : a invalid date string with 32 days in October', // date.json
+  'validation of date strings : a invalid date string with 32 days in December', // date.json
+  'validation of date strings : a invalid date string with invalid month', // date.json
+  'validation of date strings : an invalid date string', // date.json
+  'validation of date strings : only RFC3339 not all of ISO 8601 are valid', // date.json
+  'validation of date strings : non-padded month dates are not valid', // date.json
+  'validation of date strings : non-padded day dates are not valid', // date.json
+  'validation of date strings : invalid month', // date.json
+  'validation of date strings : non-ascii digits should be rejected', // date.json
 ];
 
 /// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
@@ -124,7 +139,7 @@ final List<String> skippedRelativeJsonPointerFormatTest = const [
 
 /// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
 /// There is not currently a good IDN Hostname format implementation for Dart.
-final List<String> skppedIdnHostnameFormatTests = const [
+final List<String> skippedIdnHostnameFormatTests = const [
   'validation of internationalized host names : a valid host name (example.test in Hangul)', // idn-hostname.json
   'validation of internationalized host names : valid Chinese Punycode', // idn-hostname.json
   'validation of internationalized host names : Exceptions that are PVALID, left-to-right chars', // idn-hostname.json
@@ -141,6 +156,115 @@ final List<String> skppedIdnHostnameFormatTests = const [
   'validation of internationalized host names : ZERO WIDTH JOINER preceded by Virama', // idn-hostname.json
   'validation of internationalized host names : ZERO WIDTH NON-JOINER preceded by Virama', // idn-hostname.json
   'validation of internationalized host names : ZERO WIDTH NON-JOINER not preceded by Virama but matches regexp', // idn-hostname.json
+
+  // Draft 2019 and later
+  'validation of internationalized host names : illegal first char U+302E Hangul single dot tone mark',
+  'validation of internationalized host names : contains illegal char U+302E Hangul single dot tone mark', // idn-hostname.json
+  'validation of internationalized host names : a host name with a component too long', // idn-hostname.json
+  'validation of internationalized host names : invalid label, correct Punycode', // idn-hostname.json
+  'validation of internationalized host names : invalid Punycode', // idn-hostname.json
+  'validation of internationalized host names : U-label contains "--" in the 3rd and 4th position', // idn-hostname.json
+  'validation of internationalized host names : U-label starts with a dash', // idn-hostname.json
+  'validation of internationalized host names : U-label ends with a dash', // idn-hostname.json
+  'validation of internationalized host names : U-label starts and ends with a dash', // idn-hostname.json
+  'validation of internationalized host names : Begins with a Spacing Combining Mark', // idn-hostname.json
+  'validation of internationalized host names : Begins with a Nonspacing Mark', // idn-hostname.json
+  'validation of internationalized host names : Begins with an Enclosing Mark', // idn-hostname.json
+  'validation of internationalized host names : Exceptions that are DISALLOWED, right-to-left chars', // idn-hostname.json
+  'validation of internationalized host names : Exceptions that are DISALLOWED, left-to-right chars', // idn-hostname.json
+  'validation of internationalized host names : MIDDLE DOT with no preceding \'l\'', // idn-hostname.json
+  'validation of internationalized host names : MIDDLE DOT with nothing preceding', // idn-hostname.json
+  'validation of internationalized host names : MIDDLE DOT with no following \'l\'', // idn-hostname.json
+  'validation of internationalized host names : MIDDLE DOT with nothing following', // idn-hostname.json
+  'validation of internationalized host names : Greek KERAIA not followed by Greek', // idn-hostname.json
+  'validation of internationalized host names : Greek KERAIA not followed by anything', // idn-hostname.json
+  'validation of internationalized host names : Hebrew GERESH not preceded by Hebrew', // idn-hostname.json
+  'validation of internationalized host names : Hebrew GERESH not preceded by anything', // idn-hostname.json
+  'validation of internationalized host names : Hebrew GERSHAYIM not preceded by Hebrew', // idn-hostname.json
+  'validation of internationalized host names : Hebrew GERSHAYIM not preceded by anything', // idn-hostname.json
+  'validation of internationalized host names : KATAKANA MIDDLE DOT with no Hiragana, Katakana, or Han', // idn-hostname.json
+  'validation of internationalized host names : KATAKANA MIDDLE DOT with no other characters', // idn-hostname.json
+  'validation of internationalized host names : Arabic-Indic digits mixed with Extended Arabic-Indic digits', // idn-hostname.json
+  'validation of internationalized host names : ZERO WIDTH JOINER not preceded by Virama', // idn-hostname.json
+  'validation of internationalized host names : ZERO WIDTH JOINER not preceded by anything', // idn-hostname.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedIdnEmailFormatTests = const [
+  'validation of an internationalized e-mail addresses : an invalid idn e-mail address', // idn-email.json
+  'validation of an internationalized e-mail addresses : an invalid e-mail address', // idn-email.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedIriFormatTests = const [
+  'validation of IRIs : an invalid IRI based on IPv6', // iri.json
+  'validation of IRIs : an invalid relative IRI Reference', // iri.json
+  'validation of IRIs : an invalid IRI', // iri.json
+  'validation of IRIs : an invalid IRI though valid IRI reference', // iri.json
+  'validation of IRI References : an invalid IRI Reference', // iri-reference.json
+  'validation of IRI References : an invalid IRI fragment', // iri-reference.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedJsonPointerFormatTests = const [
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (~ not escaped)', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (URI Fragment Identifier) #1', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (URI Fragment Identifier) #2', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (URI Fragment Identifier) #3', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (some escaped, but not all) #1', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (some escaped, but not all) #2', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (wrong escape character) #1', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (wrong escape character) #2', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (multiple characters not escaped)', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (isn\'t empty nor starts with /) #1', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (isn\'t empty nor starts with /) #2', // json-pointer.json
+  'validation of JSON-pointers (JSON String Representation) : not a valid JSON-pointer (isn\'t empty nor starts with /) #3', // json-pointer.json
+  'validation of Relative JSON Pointers (RJP) : negative prefix', // relative-json-pointer.json
+  'validation of Relative JSON Pointers (RJP) : ## is not a valid json-pointer',
+  'validation of Relative JSON Pointers (RJP) : zero cannot be followed by other digits, plus json-pointer', // relative-json-pointer.json
+  'validation of Relative JSON Pointers (RJP) : zero cannot be followed by other digits, plus octothorpe', // relative-json-pointer.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedRegexTests = const [
+  'validation of regular expressions : a regular expression with unclosed parens is invalid', // regex.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedTimeTests = const [
+  'validation of time strings : invalid leap second, Zulu (wrong hour)', // time.json
+  'validation of time strings : invalid leap second, Zulu (wrong minute)', // time.json
+  'validation of time strings : invalid leap second, zero time-offset (wrong hour)', // time.json
+  'validation of time strings : invalid leap second, zero time-offset (wrong minute)', // time.json
+  'validation of time strings : invalid leap second, positive time-offset (wrong hour)', // time.json
+  'validation of time strings : invalid leap second, positive time-offset (wrong minute)', // time.json
+  'validation of time strings : invalid leap second, negative time-offset (wrong hour)', // time.json
+  'validation of time strings : invalid leap second, negative time-offset (wrong minute)', // time.json
+  'validation of time strings : an invalid time string with invalid hour', // time.json
+  'validation of time strings : an invalid time string with invalid minute', // time.json
+  'validation of time strings : an invalid time string with invalid second', // time.json
+  'validation of time strings : an invalid time string with invalid leap second (wrong hour)', // time.json
+  'validation of time strings : an invalid time string with invalid leap second (wrong minute)', // time.json
+  'validation of time strings : an invalid time string with invalid time numoffset hour', // time.json
+  'validation of time strings : an invalid time string with invalid time numoffset minute', // time.json
+  'validation of time strings : an invalid time string with invalid time with both Z and numoffset', // time.json
+  'validation of time strings : an invalid offset indicator', // time.json
+  'validation of time strings : only RFC3339 not all of ISO 8601 are valid', // time.json
+  'validation of time strings : no time offset', // time.json
+  'validation of time strings : non-ascii digits should be rejected', // time.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedURITests = const [
+  'validation of URI References : an invalid URI Reference', // uri-reference.json
+  'validation of URI References : an invalid URI fragment', // uri-reference.json
+  'format: uri-template : an invalid uri-template', // uri-template.json
+];
+
+/// All Skipped tests below are OPTIONAL format tests. Implementations make a best effort to support these.
+final List<String> skippedUUIDTests = const [
+  'uuid format : hypothetical version 6', // uuid.json
+  'uuid format : hypothetical version 15', // uuid.json
 ];
 
 /// A list of tests to skip for all drafts.
@@ -150,7 +274,14 @@ final List<String> commonSkippedTests = []
   ..addAll(skippedPermissiveDateTimeFormatTests)
   ..addAll(skippedIpv6FormatTests)
   ..addAll(skippedRelativeJsonPointerFormatTest)
-  ..addAll(skppedIdnHostnameFormatTests);
+  ..addAll(skippedIdnHostnameFormatTests)
+  ..addAll(skippedIdnEmailFormatTests)
+  ..addAll(skippedIriFormatTests)
+  ..addAll(skippedJsonPointerFormatTests)
+  ..addAll(skippedRegexTests)
+  ..addAll(skippedTimeTests)
+  ..addAll(skippedURITests)
+  ..addAll(skippedUUIDTests);
 
 final List<String> draft9SkippedTestFiles = [
   "anchor.json",
@@ -193,3 +324,5 @@ final List<String> draft9SkippedTestFiles = [
   "uuid.json",
   "vocabulary.json",
 ]..addAll(commonSkippedTestFiles);
+
+final List<String> draft2019FormatSkippedTestFiles = [];

--- a/test/unit/json_schema/configurable_format_validation_test.dart
+++ b/test/unit/json_schema/configurable_format_validation_test.dart
@@ -3,28 +3,28 @@ import 'package:test/test.dart';
 
 main() {
   test('Should respect configurable format validation', () {
-    final schema = JsonSchema.create({
+    final schemaDraft7 = JsonSchema.create({
       'properties': {
-        'someKey': {'format': 'uri-template'}
+        'someKey': {'format': 'email'}
       }
-    });
+    }, schemaVersion: SchemaVersion.draft7);
 
-    final isValidFormatsOn = schema.validate({'someKey': 'http://example.com/dictionary/{term:1}/{term'});
+    final schemaDraft2019 = JsonSchema.create({
+      'properties': {
+        'someKey': {'format': 'email'}
+      }
+    }, schemaVersion: SchemaVersion.draft2019_09);
 
-    expect(isValidFormatsOn, isFalse);
+    final badlyFormatted = {'someKey': '@@@@@'};
 
-    final isValidFormatsOff =
-        schema.validate({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false);
+    expect(schemaDraft7.validate(badlyFormatted), isFalse);
+    expect(schemaDraft7.validate(badlyFormatted, validateFormats: false), isTrue);
+    expect(schemaDraft7.validateWithErrors(badlyFormatted), isNotEmpty);
+    expect(schemaDraft7.validateWithErrors(badlyFormatted, validateFormats: false), isEmpty);
 
-    expect(isValidFormatsOff, isTrue);
-
-    final errorsFormatsOn = schema.validateWithErrors({'someKey': 'http://example.com/dictionary/{term:1}/{term'});
-
-    expect(errorsFormatsOn, isNotEmpty);
-
-    final errorsFormatsOff =
-        schema.validateWithErrors({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false);
-
-    expect(errorsFormatsOff, isEmpty);
+    expect(schemaDraft2019.validate(badlyFormatted), isTrue);
+    expect(schemaDraft2019.validate(badlyFormatted, validateFormats: true), isFalse);
+    expect(schemaDraft2019.validateWithErrors(badlyFormatted), isEmpty);
+    expect(schemaDraft2019.validateWithErrors(badlyFormatted, validateFormats: true), isNotEmpty);
   });
 }

--- a/test/unit/json_schema/specification_test.dart
+++ b/test/unit/json_schema/specification_test.dart
@@ -54,10 +54,12 @@ void main() {
       specificationTests.entries.where((MapEntry<String, String> entry) => entry.key.startsWith('/draft7'));
   final allDraft2019 =
       specificationTests.entries.where((MapEntry<String, String> entry) => entry.key.startsWith('/draft2019-09'));
+  final draft2019Format = specificationTests.entries
+      .where((MapEntry<String, String> entry) => entry.key.startsWith('/draft2019-09/optional/format'));
 
   final runAllTestsForDraftX = (SchemaVersion schemaVersion, Iterable<MapEntry<String, String>> allTests,
       List<String> skipFiles, List<String> skipTests,
-      {bool isSync = false, RefProvider refProvider}) {
+      {bool isSync = false, bool validateFormats, RefProvider refProvider}) {
     String shortSchemaVersion = schemaVersion.toString();
     if (schemaVersion == SchemaVersion.draft4) {
       shortSchemaVersion = 'draft4';
@@ -108,13 +110,13 @@ void main() {
                     schemaVersion: schemaVersion,
                     refProvider: refProvider,
                   );
-                  validationResults = schema.validateWithErrors(instance);
+                  validationResults = schema.validateWithErrors(instance, validateFormats: validateFormats);
                   expect(validationResults.isEmpty, expectedResult);
                 } else {
                   final checkResultAsync = expectAsync2(checkResult);
                   JsonSchema.createAsync(schemaData, schemaVersion: schemaVersion, refProvider: refProvider)
                       .then((schema) {
-                    validationResults = schema.validateWithErrors(instance);
+                    validationResults = schema.validateWithErrors(instance, validateFormats: validateFormats);
                     checkResultAsync(validationResults, expectedResult);
                   });
                 }
@@ -179,6 +181,13 @@ void main() {
     draft9SkippedTestFiles,
     commonSkippedTests,
   );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    validateFormats: true,
+  );
 
   // Run all tests synchronously with a sync ref provider.
   runAllTestsForDraftX(
@@ -212,6 +221,15 @@ void main() {
     commonSkippedTests,
     isSync: true,
     refProvider: deprecatedSyncRefSchemaProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    isSync: true,
+    refProvider: deprecatedSyncRefSchemaProvider,
+    validateFormats: true,
   );
 
   // Run all tests synchronously with a sync json provider.
@@ -255,6 +273,15 @@ void main() {
     isSync: true,
     refProvider: syncRefProvider,
   );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    isSync: true,
+    refProvider: syncRefProvider,
+    validateFormats: true,
+  );
 
   // Run all tests asynchronously with an async ref provider.
   runAllTestsForDraftX(
@@ -292,6 +319,14 @@ void main() {
     commonSkippedTests,
     refProvider: deprecatedAsyncRefSchemaProvider,
   );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: deprecatedAsyncRefSchemaProvider,
+    validateFormats: true,
+  );
 
   // Run all tests asynchronously with an async json provider.
   runAllTestsForDraftX(
@@ -328,5 +363,13 @@ void main() {
     draft9SkippedTestFiles,
     commonSkippedTests,
     refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+    validateFormats: true,
   );
 }


### PR DESCRIPTION
## Ultimate problem:
We need to support Draft 2019's new format options, and format validation behavioral default (off).

## How it was fixed:
Do it.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf