### PR TITLE
Implement $vocabulary Support

### DIFF
--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -178,7 +178,7 @@ final _staticSchemaMapping = {
 };
 
 Uri parseStandardizedUri(String s) => standardizeUri(Uri.parse(s));
-Uri standardizeUri(Uri uri) => uri?.replace(scheme: "https", fragment: null);
+Uri standardizeUri(Uri uri) => uri?.replace(scheme: uri.scheme == "http" ? "https" : uri.scheme, fragment: null);
 
 Map getStaticSchema(String ref) {
   return getStaticSchemaByURI(parseStandardizedUri(ref));

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -158,7 +158,7 @@ class SchemaVersion implements Comparable<SchemaVersion> {
   }
 }
 
-Map getJsonSchemaDefinitionByRef(String ref) {
+Map getStaticSchemaDefinitionById(String ref) {
   final mapping = {
     SchemaVersion.draft4.toString(): JsonSchemaDefinitions.draft4,
     SchemaVersion.draft6.toString(): JsonSchemaDefinitions.draft6,
@@ -997,4 +997,21 @@ class Draft2019Subschemas {
         "contentSchema": { "$recursiveRef": "#" }
     }
 }''';
+}
+
+class SupportedVocabularies {
+  static final CORE = Uri.parse("https://json-schema.org/draft/2019-09/vocab/core");
+  static final APPLICATOR = Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator");
+  static final VALIDATION = Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation");
+  static final METADATA = Uri.parse("https://json-schema.org/draft/2019-09/vocab/meta-data");
+  static final FORMAT = Uri.parse("https://json-schema.org/draft/2019-09/vocab/format");
+  static final CONTENT = Uri.parse("https://json-schema.org/draft/2019-09/vocab/content");
+  static final ALL = {
+    CORE,
+    APPLICATOR,
+    VALIDATION,
+    METADATA,
+    FORMAT,
+    CONTENT,
+  };
 }

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -158,35 +158,33 @@ class SchemaVersion implements Comparable<SchemaVersion> {
   }
 }
 
-class StaticSchemas {
-  static final _mapping = {
-    Uri.parse(SchemaVersion.draft4.toString()).removeFragment(): JsonSchemaDefinitions.draft4,
-    Uri.parse(SchemaVersion.draft6.toString()).removeFragment(): JsonSchemaDefinitions.draft6,
-    Uri.parse(SchemaVersion.draft7.toString()).removeFragment(): JsonSchemaDefinitions.draft7,
-    Uri.parse(SchemaVersion.draft2019_09.toString()).removeFragment(): JsonSchemaDefinitions.draft2019_09,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/validation"): Draft2019Subschemas.validation,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation"): Draft2019Subschemas.validation,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/format"): Draft2019Subschemas.format,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/format"): Draft2019Subschemas.format,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/core"): Draft2019Subschemas.core,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/core"): Draft2019Subschemas.core,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/metadata"): Draft2019Subschemas.metadata,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/metadata"): Draft2019Subschemas.metadata,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/applicator"): Draft2019Subschemas.applicator,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator"): Draft2019Subschemas.applicator,
-    Uri.parse("https://json-schema.org/draft/2019-09/meta/content"): Draft2019Subschemas.content,
-    Uri.parse("https://json-schema.org/draft/2019-09/vocab/content"): Draft2019Subschemas.content,
-  };
+final _staticSchemaMapping = {
+  Uri.parse(SchemaVersion.draft4.toString()).removeFragment(): JsonSchemaDefinitions.draft4,
+  Uri.parse(SchemaVersion.draft6.toString()).removeFragment(): JsonSchemaDefinitions.draft6,
+  Uri.parse(SchemaVersion.draft7.toString()).removeFragment(): JsonSchemaDefinitions.draft7,
+  Uri.parse(SchemaVersion.draft2019_09.toString()).removeFragment(): JsonSchemaDefinitions.draft2019_09,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/validation"): Draft2019Subschemas.validation,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation"): Draft2019Subschemas.validation,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/format"): Draft2019Subschemas.format,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/format"): Draft2019Subschemas.format,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/core"): Draft2019Subschemas.core,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/core"): Draft2019Subschemas.core,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/metadata"): Draft2019Subschemas.metadata,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/metadata"): Draft2019Subschemas.metadata,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/applicator"): Draft2019Subschemas.applicator,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator"): Draft2019Subschemas.applicator,
+  Uri.parse("https://json-schema.org/draft/2019-09/meta/content"): Draft2019Subschemas.content,
+  Uri.parse("https://json-schema.org/draft/2019-09/vocab/content"): Draft2019Subschemas.content,
+};
 
-  static Map get(String ref) {
-    return getByURI(Uri.parse(ref));
-  }
+Map getStaticSchema(String ref) {
+  return getStaticSchemaByURI(Uri.parse(ref));
+}
 
-  static Map getByURI(Uri ref) {
-    if (ref.fragment != "") return null;
-    final mapped = _mapping[ref.removeFragment()];
-    return mapped != null ? json.decode(mapped) : null;
-  }
+Map getStaticSchemaByURI(Uri ref) {
+  if (ref.fragment != "") return null;
+  final mapped = _staticSchemaMapping[ref.removeFragment()];
+  return mapped != null ? json.decode(mapped) : null;
 }
 
 class JsonSchemaDefinitions {

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -164,13 +164,22 @@ Map getJsonSchemaDefinitionByRef(String ref) {
     SchemaVersion.draft6.toString(): JsonSchemaDefinitions.draft6,
     SchemaVersion.draft7.toString(): JsonSchemaDefinitions.draft7,
     SchemaVersion.draft2019_09.toString(): JsonSchemaDefinitions.draft2019_09,
+    "https://json-schema.org/draft/2019-09/meta/validation": Draft2019Subschemas.validation,
+    "https://json-schema.org/draft/2019-09/vocab/validation": Draft2019Subschemas.validation,
+    "https://json-schema.org/draft/2019-09/meta/format": Draft2019Subschemas.format,
+    "https://json-schema.org/draft/2019-09/vocab/format": Draft2019Subschemas.format,
+    "https://json-schema.org/draft/2019-09/meta/core": Draft2019Subschemas.core,
+    "https://json-schema.org/draft/2019-09/vocab/core": Draft2019Subschemas.core,
+    "https://json-schema.org/draft/2019-09/meta/metadata": Draft2019Subschemas.metadata,
+    "https://json-schema.org/draft/2019-09/vocab/metadata": Draft2019Subschemas.metadata,
+    "https://json-schema.org/draft/2019-09/meta/applicator": Draft2019Subschemas.applicator,
+    "https://json-schema.org/draft/2019-09/vocab/applicator": Draft2019Subschemas.applicator,
+    "https://json-schema.org/draft/2019-09/meta/content": Draft2019Subschemas.content,
+    "https://json-schema.org/draft/2019-09/vocab/content": Draft2019Subschemas.content,
   };
 
-  if (SchemaVersion.values.map((value) => value.toString()).contains(ref)) {
-    return json.decode(mapping[ref]);
-  }
-
-  return null;
+  final mapped = mapping[ref];
+  return mapped != null ? json.decode(mapped) : null;
 }
 
 class JsonSchemaDefinitions {

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -183,6 +183,7 @@ class StaticSchemas {
   }
 
   static Map getByURI(Uri ref) {
+    if (ref.fragment != "") return null;
     final mapped = _mapping[ref.removeFragment()];
     return mapped != null ? json.decode(mapped) : null;
   }

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -158,32 +158,38 @@ class SchemaVersion implements Comparable<SchemaVersion> {
   }
 }
 
-Map getStaticSchemaDefinitionById(String ref) {
-  final mapping = {
-    SchemaVersion.draft4.toString(): JsonSchemaDefinitions.draft4,
-    SchemaVersion.draft6.toString(): JsonSchemaDefinitions.draft6,
-    SchemaVersion.draft7.toString(): JsonSchemaDefinitions.draft7,
-    SchemaVersion.draft2019_09.toString(): JsonSchemaDefinitions.draft2019_09,
-    "https://json-schema.org/draft/2019-09/meta/validation": Draft2019Subschemas.validation,
-    "https://json-schema.org/draft/2019-09/vocab/validation": Draft2019Subschemas.validation,
-    "https://json-schema.org/draft/2019-09/meta/format": Draft2019Subschemas.format,
-    "https://json-schema.org/draft/2019-09/vocab/format": Draft2019Subschemas.format,
-    "https://json-schema.org/draft/2019-09/meta/core": Draft2019Subschemas.core,
-    "https://json-schema.org/draft/2019-09/vocab/core": Draft2019Subschemas.core,
-    "https://json-schema.org/draft/2019-09/meta/metadata": Draft2019Subschemas.metadata,
-    "https://json-schema.org/draft/2019-09/vocab/metadata": Draft2019Subschemas.metadata,
-    "https://json-schema.org/draft/2019-09/meta/applicator": Draft2019Subschemas.applicator,
-    "https://json-schema.org/draft/2019-09/vocab/applicator": Draft2019Subschemas.applicator,
-    "https://json-schema.org/draft/2019-09/meta/content": Draft2019Subschemas.content,
-    "https://json-schema.org/draft/2019-09/vocab/content": Draft2019Subschemas.content,
+class StaticSchemas {
+  static final _mapping = {
+    Uri.parse(SchemaVersion.draft4.toString()).removeFragment(): JsonSchemaDefinitions.draft4,
+    Uri.parse(SchemaVersion.draft6.toString()).removeFragment(): JsonSchemaDefinitions.draft6,
+    Uri.parse(SchemaVersion.draft7.toString()).removeFragment(): JsonSchemaDefinitions.draft7,
+    Uri.parse(SchemaVersion.draft2019_09.toString()).removeFragment(): JsonSchemaDefinitions.draft2019_09,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/validation"): Draft2019Subschemas.validation,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation"): Draft2019Subschemas.validation,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/format"): Draft2019Subschemas.format,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/format"): Draft2019Subschemas.format,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/core"): Draft2019Subschemas.core,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/core"): Draft2019Subschemas.core,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/metadata"): Draft2019Subschemas.metadata,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/metadata"): Draft2019Subschemas.metadata,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/applicator"): Draft2019Subschemas.applicator,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator"): Draft2019Subschemas.applicator,
+    Uri.parse("https://json-schema.org/draft/2019-09/meta/content"): Draft2019Subschemas.content,
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/content"): Draft2019Subschemas.content,
   };
 
-  final mapped = mapping[ref];
-  return mapped != null ? json.decode(mapped) : null;
+  static Map get(String ref) {
+    return getByURI(Uri.parse(ref));
+  }
+
+  static Map getByURI(Uri ref) {
+    final mapped = _mapping[ref.removeFragment()];
+    return mapped != null ? json.decode(mapped) : null;
+  }
 }
 
 class JsonSchemaDefinitions {
-  static String draft4 = r'''
+  static final String draft4 = r'''
     {
     "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -335,7 +341,7 @@ class JsonSchemaDefinitions {
 }
     ''';
 
-  static String draft6 = r'''
+  static final String draft6 = r'''
     {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://json-schema.org/draft-06/schema#",
@@ -492,7 +498,7 @@ class JsonSchemaDefinitions {
 }
     ''';
 
-  static String draft7 = r'''{
+  static final String draft7 = r'''{
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "http://json-schema.org/draft-07/schema#",
     "title": "Core schema meta-schema",
@@ -666,7 +672,7 @@ class JsonSchemaDefinitions {
 }
   ''';
 
-  static String draft2019_09 = r'''{
+  static final String draft2019_09 = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/schema",
     "$vocabulary": {
@@ -720,7 +726,7 @@ class JsonSchemaDefinitions {
 }
 
 class Draft2019Subschemas {
-  static String format = r'''{
+  static final String format = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/format",
     "$vocabulary": {
@@ -735,7 +741,7 @@ class Draft2019Subschemas {
     }
 }''';
 
-  static String core = r'''{
+  static final String core = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/core",
     "$vocabulary": {
@@ -793,7 +799,7 @@ class Draft2019Subschemas {
     }
 }''';
 
-  static String applicator = r'''{
+  static final String applicator = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/applicator",
     "$vocabulary": {
@@ -850,7 +856,7 @@ class Draft2019Subschemas {
     }
 }''';
 
-  static String validation = r'''{
+  static final String validation = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/validation",
     "$vocabulary": {
@@ -949,7 +955,7 @@ class Draft2019Subschemas {
     }
 }''';
 
-  static String metadata = r'''{
+  static final String metadata = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
     "$vocabulary": {
@@ -987,7 +993,7 @@ class Draft2019Subschemas {
     }
 }''';
 
-  static String content = r'''{
+  static final String content = r'''{
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$id": "https://json-schema.org/draft/2019-09/meta/content",
     "$vocabulary": {

--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -159,31 +159,34 @@ class SchemaVersion implements Comparable<SchemaVersion> {
 }
 
 final _staticSchemaMapping = {
-  Uri.parse(SchemaVersion.draft4.toString()).removeFragment(): JsonSchemaDefinitions.draft4,
-  Uri.parse(SchemaVersion.draft6.toString()).removeFragment(): JsonSchemaDefinitions.draft6,
-  Uri.parse(SchemaVersion.draft7.toString()).removeFragment(): JsonSchemaDefinitions.draft7,
-  Uri.parse(SchemaVersion.draft2019_09.toString()).removeFragment(): JsonSchemaDefinitions.draft2019_09,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/validation"): Draft2019Subschemas.validation,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation"): Draft2019Subschemas.validation,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/format"): Draft2019Subschemas.format,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/format"): Draft2019Subschemas.format,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/core"): Draft2019Subschemas.core,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/core"): Draft2019Subschemas.core,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/metadata"): Draft2019Subschemas.metadata,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/metadata"): Draft2019Subschemas.metadata,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/applicator"): Draft2019Subschemas.applicator,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator"): Draft2019Subschemas.applicator,
-  Uri.parse("https://json-schema.org/draft/2019-09/meta/content"): Draft2019Subschemas.content,
-  Uri.parse("https://json-schema.org/draft/2019-09/vocab/content"): Draft2019Subschemas.content,
+  parseStandardizedUri(SchemaVersion.draft4.toString()): JsonSchemaDefinitions.draft4,
+  parseStandardizedUri(SchemaVersion.draft6.toString()): JsonSchemaDefinitions.draft6,
+  parseStandardizedUri(SchemaVersion.draft7.toString()): JsonSchemaDefinitions.draft7,
+  parseStandardizedUri(SchemaVersion.draft2019_09.toString()): JsonSchemaDefinitions.draft2019_09,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/validation"): Draft2019Subschemas.validation,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/validation"): Draft2019Subschemas.validation,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/format"): Draft2019Subschemas.format,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/format"): Draft2019Subschemas.format,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/core"): Draft2019Subschemas.core,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/core"): Draft2019Subschemas.core,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/metadata"): Draft2019Subschemas.metadata,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/metadata"): Draft2019Subschemas.metadata,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/applicator"): Draft2019Subschemas.applicator,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/applicator"): Draft2019Subschemas.applicator,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/meta/content"): Draft2019Subschemas.content,
+  parseStandardizedUri("https://json-schema.org/draft/2019-09/vocab/content"): Draft2019Subschemas.content,
 };
 
+Uri parseStandardizedUri(String s) => standardizeUri(Uri.parse(s));
+Uri standardizeUri(Uri uri) => uri?.replace(scheme: "https", fragment: null);
+
 Map getStaticSchema(String ref) {
-  return getStaticSchemaByURI(Uri.parse(ref));
+  return getStaticSchemaByURI(parseStandardizedUri(ref));
 }
 
 Map getStaticSchemaByURI(Uri ref) {
   if (ref.fragment != "") return null;
-  final mapped = _staticSchemaMapping[ref.removeFragment()];
+  final mapped = _staticSchemaMapping[standardizeUri(ref)];
   return mapped != null ? json.decode(mapped) : null;
 }
 

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -362,7 +362,7 @@ class JsonSchema {
             localSchema = _refMap[baseUriString];
           } else if (baseUriString != null && SchemaVersion.fromString(baseUriString) != null) {
             // If the referenced URI is or within versioned schema spec.
-            localSchema = JsonSchema.create(getStaticSchemaDefinitionById(baseUriString));
+            localSchema = JsonSchema.create(StaticSchemas.get(baseUriString));
             _addSchemaToRefMap(baseUriString, localSchema);
           } else {
             // The remote ref needs to be resolved if the above checks failed.
@@ -591,9 +591,8 @@ class JsonSchema {
     // 1. Statically-known schema definition (skips ref provider)
     // 2. Base URI (example: localhost:1234/integer.json)
     // 3. Base URI with empty fragment (example: localhost:1234/integer.json#)
-    final dynamic schemaDefinition = getStaticSchemaDefinitionById(ref.toString()) ??
-        _refProvider.provide(baseUri.toString()) ??
-        _refProvider.provide('${baseUri}#');
+    final dynamic schemaDefinition =
+        StaticSchemas.getByURI(ref) ?? _refProvider.provide(baseUri.toString()) ?? _refProvider.provide('${baseUri}#');
 
     return _createAndResolveProvidedSchema(ref, schemaDefinition);
   }
@@ -612,7 +611,7 @@ class JsonSchema {
     // 1. Statically-known schema definition (skips ref provider)
     // 2. Base URI (example: localhost:1234/integer.json)
     // 3. Base URI with empty fragment (example: localhost:1234/integer.json#)
-    final dynamic schemaDefinition = getStaticSchemaDefinitionById(ref.toString()) ??
+    final dynamic schemaDefinition = StaticSchemas.getByURI(ref) ??
         await refProvider.provide(baseUri.toString()) ??
         await refProvider.provide('${baseUri}#');
 
@@ -1358,7 +1357,7 @@ class JsonSchema {
   /// Spec: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.1.2
   Map<Uri, bool> metaschemaVocabulary() {
     return this._refMap[_schema?.toString()]?.vocabulary ??
-        JsonSchema._fromRootMap(getStaticSchemaDefinitionById(schemaVersion.toString()), _schemaVersion).vocabulary;
+        JsonSchema._fromRootMap(StaticSchemas.get(schemaVersion.toString()), _schemaVersion).vocabulary;
   }
 
   // --------------------------------------------------------------------------

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -362,7 +362,7 @@ class JsonSchema {
             localSchema = _refMap[baseUriString];
           } else if (baseUriString != null && SchemaVersion.fromString(baseUriString) != null) {
             // If the referenced URI is or within versioned schema spec.
-            localSchema = JsonSchema.create(StaticSchemas.get(baseUriString));
+            localSchema = JsonSchema.create(getStaticSchema(baseUriString));
             _addSchemaToRefMap(baseUriString, localSchema);
           } else {
             // The remote ref needs to be resolved if the above checks failed.
@@ -592,7 +592,7 @@ class JsonSchema {
     // 2. Base URI (example: localhost:1234/integer.json)
     // 3. Base URI with empty fragment (example: localhost:1234/integer.json#)
     final dynamic schemaDefinition =
-        StaticSchemas.getByURI(ref) ?? _refProvider.provide(baseUri.toString()) ?? _refProvider.provide('${baseUri}#');
+        getStaticSchemaByURI(ref) ?? _refProvider.provide(baseUri.toString()) ?? _refProvider.provide('${baseUri}#');
 
     return _createAndResolveProvidedSchema(ref, schemaDefinition);
   }
@@ -611,7 +611,7 @@ class JsonSchema {
     // 1. Statically-known schema definition (skips ref provider)
     // 2. Base URI (example: localhost:1234/integer.json)
     // 3. Base URI with empty fragment (example: localhost:1234/integer.json#)
-    final dynamic schemaDefinition = StaticSchemas.getByURI(ref) ??
+    final dynamic schemaDefinition = getStaticSchemaByURI(ref) ??
         await refProvider.provide(baseUri.toString()) ??
         await refProvider.provide('${baseUri}#');
 
@@ -1357,7 +1357,7 @@ class JsonSchema {
   /// Spec: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.1.2
   Map<Uri, bool> metaschemaVocabulary() {
     return this._refMap[_schema?.toString()]?.vocabulary ??
-        JsonSchema._fromRootMap(StaticSchemas.get(schemaVersion.toString()), _schemaVersion).vocabulary;
+        JsonSchema._fromRootMap(getStaticSchema(schemaVersion.toString()), _schemaVersion).vocabulary;
   }
 
   // --------------------------------------------------------------------------

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1333,7 +1333,7 @@ class JsonSchema {
   /// The vocabularies defined for the [JsonSchema].
   ///
   /// Spec: https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.10.3
-  Map<Uri, bool> get vocabulary => _root.vocabulary ?? Map<Uri, bool>();
+  Map<Uri, bool> get vocabulary => _root._vocabulary ?? Map<Uri, bool>();
 
   // --------------------------------------------------------------------------
   // Schema List Item Related Getters

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -362,8 +362,10 @@ class JsonSchema {
             localSchema = _refMap[baseUriString];
           } else if (baseUriString != null && SchemaVersion.fromString(baseUriString) != null) {
             // If the referenced URI is or within versioned schema spec.
-            localSchema = JsonSchema.create(getStaticSchema(baseUriString));
-            _addSchemaToRefMap(baseUriString, localSchema);
+            final staticSchema = getStaticSchema(baseUriString);
+            if (staticSchema != null) {
+              _addSchemaToRefMap(baseUriString, JsonSchema.create(staticSchema));
+            }
           } else {
             // The remote ref needs to be resolved if the above checks failed.
             resolvedSuccessfully = false;
@@ -1353,7 +1355,7 @@ class JsonSchema {
   /// The vocabularies defined by this [JsonSchema].
   ///
   /// Spec: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.1.2
-  Map<Uri, bool> get vocabulary => _vocabulary ?? Map<Uri, bool>();
+  Map<Uri, bool> get vocabulary => _vocabulary;
 
   /// The vocabularies defined by the metaschema of this [JsonSchema].
   ///

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1309,10 +1309,10 @@ class JsonSchema {
   /// Spec: https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.10.3
   bool get writeOnly => _writeOnly;
 
-  /// Whether the JSON Schema is write-only.
+  /// The vocabularies defined for the [JsonSchema].
   ///
   /// Spec: https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.10.3
-  Map<Uri, bool> get vocabulary => _vocabulary;
+  Map<Uri, bool> get vocabulary => _root.vocabulary ?? Map<Uri, bool>();
 
   // --------------------------------------------------------------------------
   // Schema List Item Related Getters

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -166,7 +166,7 @@ class Validator {
           }
         }
       });
-      return Set.of(vocab?.keys ?? []).intersection(SupportedVocabularies.ALL);
+      return Set.of(vocab?.keys ?? Set<Uri>()).intersection(SupportedVocabularies.ALL);
     }
   }
 

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -114,6 +114,7 @@ class Validator {
     _validateFormats = validateFormats;
     _treatWarningsAsErrors = treatWarningsAsErrors;
 
+    // TODO error if required vocabularies has something unknown
     dynamic data = instance;
     if (parseJson && instance is String) {
       try {
@@ -650,4 +651,29 @@ class Validator {
   List<ValidationError> _errors = [];
   List<ValidationError> _warnings = [];
   bool _reportMultipleErrors;
+}
+
+class Vocabularies {
+  static final _supported = {
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/core"),
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/applicator"),
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/validation"),
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/meta-data"),
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/format"),
+    Uri.parse("https://json-schema.org/draft/2019-09/vocab/content"),
+  };
+
+  Vocabularies.fromDefined(Map<Uri, bool> v) {
+    v.forEach((uri, isRequired) {
+      declared.add(uri);
+      if (!_supported.contains(uri)) unsupported.add(uri);
+      if (isRequired) required.add(uri);
+    });
+  }
+
+  /// Vocabularies declared for use for validation.
+  final Set<Uri> declared = {};
+
+  final Set<Uri> unsupported = {};
+  final Set<Uri> required = {};
 }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -349,6 +349,7 @@ class Validator {
   void _validateAllOf(JsonSchema schema, Instance instance) {
     final warnOrErr = _errFuncForVocabulary(SupportedVocabularies.APPLICATOR);
     if (!schema.allOf.every((s) => Validator(s).validate(instance))) {
+      // TODO consider passing back validation errors from sub-validations
       warnOrErr('${schema.path}: allOf violated ${instance}', instance.path, schema.path + '/allOf');
     }
   }
@@ -356,6 +357,7 @@ class Validator {
   void _validateAnyOf(JsonSchema schema, Instance instance) {
     final warnOrErr = _errFuncForVocabulary(SupportedVocabularies.APPLICATOR);
     if (!schema.anyOf.any((s) => Validator(s).validate(instance))) {
+      // TODO consider passing back validation errors from sub-validations
       warnOrErr(
           '${schema.path}/anyOf: anyOf violated ($instance, ${schema.anyOf})', instance.path, schema.path + '/anyOf');
     }
@@ -365,6 +367,7 @@ class Validator {
     try {
       schema.oneOf.singleWhere((s) => Validator(s).validate(instance));
     } on StateError catch (notOneOf) {
+      // TODO consider passing back validation errors from sub-validations
       _errFuncForVocabulary(SupportedVocabularies.APPLICATOR)(
           '${schema.path}/oneOf: violated ${notOneOf.message}', instance.path, schema.path + '/oneOf');
     }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -160,7 +160,7 @@ class Validator {
       vocab?.forEach((uri, isRequired) {
         if (!SupportedVocabularies.ALL.contains(uri)) {
           if (isRequired) {
-            throw ArgumentError("unsupported vocabulary required for validation", "$uri");
+            throw ArgumentError('unsupported vocabulary required for validation', '$uri');
           } else {
             _warn('unsupported optional vocabulary in use: $uri', '', r'$schema');
           }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -133,6 +133,7 @@ class Validator {
     }
 
     _reportMultipleErrors = reportMultipleErrors;
+    _errors = [];
     // Initialize and validate the vocabulary to be used for validation
     _vocabulary = getVocabulary(_rootSchema);
     if (!_reportMultipleErrors) {

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -191,5 +191,5 @@ final List<String> draft9SkippedTestFiles = [
   "uri-reference.json",
   "uri-template.json",
   "uuid.json",
-  "vocabulary.json",
+  //"vocabulary.json",
 ]..addAll(commonSkippedTestFiles);

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -287,7 +287,6 @@ final List<String> draft2019SkippedTestFiles = [
   // WIP
   "unevaluatedItems.json",
   "unevaluatedProperties.json",
-  "vocabulary.json",
 
   // As of Draft 2019, format validation becomes an opt-in option.
   // We *do* run the optional format test files below, but they appear

--- a/test/unit/constants.dart
+++ b/test/unit/constants.dart
@@ -306,7 +306,6 @@ final List<String> draft2019SkippedTestFiles = [
   "uri-reference.json",
   "uri-template.json",
   "uuid.json",
-  //"vocabulary.json",
 ]..addAll(commonSkippedTestFiles);
 
 final List<String> draft2019SkippedTests = [


### PR DESCRIPTION
## Ultimate problem:
We need to implement support for (1) gathering the `$vocabulary` property of a schema, and (2) validating according to the vocabularies in use that we support.

## How it was fixed:
Do it.

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf