### PR TITLE
Ignore Old Keywords $definitions and $dependencies

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1000,6 +1000,9 @@ class JsonSchema {
   static Map<String, SchemaPropertySetter> _accessMapV2019_09 = Map<String, SchemaPropertySetter>()
     ..addAll(_baseAccessMap)
     ..addAll(_accessMapV7)
+    // Unfortunately the spec does not explicitly say to ignore these old keywords,
+    // nor do the spec tests offer an answer. However, the sane thing to do seems to be to ignore them,
+    // otherwise we get into undocumented territory.
     ..remove(r'$definitions')
     ..remove(r'$dependencies')
     ..addAll({

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1000,6 +1000,8 @@ class JsonSchema {
   static Map<String, SchemaPropertySetter> _accessMapV2019_09 = Map<String, SchemaPropertySetter>()
     ..addAll(_baseAccessMap)
     ..addAll(_accessMapV7)
+    ..remove(r'$definitions')
+    ..remove(r'$dependencies')
     ..addAll({
       // Note: see https://json-schema.org/draft/2019-09/release-notes.html
 

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1000,6 +1000,9 @@ class JsonSchema {
   static Map<String, SchemaPropertySetter> _accessMapV2019_09 = Map<String, SchemaPropertySetter>()
     ..addAll(_baseAccessMap)
     ..addAll(_accessMapV7)
+    // "Note that the standard meta-schema still reserves definitions for backwards compatibility"
+    // https://json-schema.org/draft/2019-09/release-notes.html#core-vocabulary
+    // https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.8.2.5
     // Unfortunately the spec does not explicitly say to ignore these old keywords,
     // nor do the spec tests offer an answer. However, the sane thing to do seems to be to ignore them,
     // otherwise we get into undocumented territory.


### PR DESCRIPTION
## Ultimate problem:
As of Draft 2019, `$definitions` and `$dependencies` remain reserved, but are no longer official keywords.

## How it was fixed:
Ignore them

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf