### PR TITLE
Update to latest JSON-Schema-Test-Suite

### DIFF
--- a/test/JSON-Schema-Test-Suite/README.md
+++ b/test/JSON-Schema-Test-Suite/README.md
@@ -199,6 +199,10 @@ which also welcomes your contributions!
 * [jsonschema](https://github.com/Stranger6667/jsonschema-rs)
 * [valico](https://github.com/rustless/valico)
 
+### Scala
+
+* [typed-json](https://github.com/frawa/typed-json)
+
 ### Swift
 
 * [JSONSchema](https://github.com/kylef/JSONSchema.swift)

--- a/test/JSON-Schema-Test-Suite/bin/jsonschema_suite
+++ b/test/JSON-Schema-Test-Suite/bin/jsonschema_suite
@@ -1,6 +1,4 @@
 #! /usr/bin/env python3
-from __future__ import print_function
-from pprint import pformat
 import argparse
 import errno
 import fnmatch
@@ -12,9 +10,6 @@ import sys
 import textwrap
 import unittest
 import warnings
-
-if getattr(unittest, "skipIf", None) is None:
-    unittest.skipIf = lambda cond, msg : lambda fn : fn
 
 try:
     import jsonschema.validators
@@ -33,18 +28,27 @@ with open(os.path.join(ROOT_DIR, "test-schema.json")) as schema:
 
 
 def files(paths):
+    """
+    Each test file in the provided paths.
+    """
     for path in paths:
         with open(path) as test_file:
             yield json.load(test_file)
 
 
 def groups(paths):
+    """
+    Each test group within each file in the provided paths.
+    """
     for test_file in files(paths):
         for group in test_file:
             yield group
 
 
 def cases(paths):
+    """
+    Each individual test case within all groups within the provided paths.
+    """
     for test_group in groups(paths):
         for test in test_group["tests"]:
             test["schema"] = test_group["schema"]
@@ -52,6 +56,9 @@ def cases(paths):
 
 
 def collect(root_dir):
+    """
+    All of the test file paths within the given root directory, recursively.
+    """
     for root, _, files in os.walk(root_dir):
         for filename in fnmatch.filter(files, "*.json"):
             yield os.path.join(root, filename)

--- a/test/JSON-Schema-Test-Suite/remotes/draft-next/format-assertion-false.json
+++ b/test/JSON-Schema-Test-Suite/remotes/draft-next/format-assertion-false.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}

--- a/test/JSON-Schema-Test-Suite/remotes/draft-next/format-assertion-true.json
+++ b/test/JSON-Schema-Test-Suite/remotes/draft-next/format-assertion-true.json
@@ -1,0 +1,12 @@
+{
+    "$id": "http://localhost:1234/draft-next/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}

--- a/test/JSON-Schema-Test-Suite/remotes/draft-next/metaschema-no-validation.json
+++ b/test/JSON-Schema-Test-Suite/remotes/draft-next/metaschema-no-validation.json
@@ -1,0 +1,11 @@
+{
+    "$id": "http://localhost:1234/draft-next/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/next/meta/core" }
+    ]
+}

--- a/test/JSON-Schema-Test-Suite/tests/draft-next/optional/format-assertion.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft-next/optional/format-assertion.json
@@ -3,7 +3,7 @@
         "description": "schema that uses custom metaschema with format-assertion: false",
         "schema": {
             "$id": "https://schema/using/format-assertion/false",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-false.json",
             "format": "ipv4"
         },
         "tests": [
@@ -23,7 +23,7 @@
         "description": "schema that uses custom metaschema with format-assertion: true",
         "schema": {
             "$id": "https://schema/using/format-assertion/true",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-true.json",
             "format": "ipv4"
         },
         "tests": [

--- a/test/JSON-Schema-Test-Suite/tests/draft-next/vocabulary.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft-next/vocabulary.json
@@ -3,7 +3,7 @@
         "description": "schema that uses custom metaschema with with no validation vocabulary",
         "schema": {
             "$id": "https://schema/using/no/validation",
-            "$schema": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+            "$schema": "http://localhost:1234/draft-next/metaschema-no-validation.json",
             "properties": {
                 "badProperty": false,
                 "numberProperty": {

--- a/test/JSON-Schema-Test-Suite/tests/draft2019-09/optional/format/unknown.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft2019-09/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/JSON-Schema-Test-Suite/tests/draft2020-12/optional/format/unknown.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft2020-12/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/JSON-Schema-Test-Suite/tests/draft4/optional/format/unknown.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft4/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/JSON-Schema-Test-Suite/tests/draft6/contains.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft6/contains.json
@@ -125,26 +125,5 @@
                 "valid": false
             }
         ]
-    },
-    {
-        "description": "contains with false if subschema",
-        "schema": {
-            "contains": {
-                "if": false,
-                "else": true
-            }
-        },
-        "tests": [
-            {
-                "description": "any non-empty array is valid",
-                "data": ["foo"],
-                "valid": true
-            },
-            {
-                "description": "empty array is invalid",
-                "data": [],
-                "valid": false
-            }
-        ]
     }
 ]

--- a/test/JSON-Schema-Test-Suite/tests/draft6/optional/format/unknown.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft6/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/JSON-Schema-Test-Suite/tests/draft7/optional/format/unknown.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft7/optional/format/unknown.json
@@ -1,0 +1,43 @@
+[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/unit/specification_remotes.dart
+++ b/test/unit/specification_remotes.dart
@@ -12,6 +12,44 @@ Map<String, String> specificationRemotes = {
     "type": "integer"
 }
 """,
+  "http://localhost:1234/draft-next/format-assertion-false.json": r"""{
+    "$id": "http://localhost:1234/draft-next/format-assertion-false.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": false
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}
+""",
+  "http://localhost:1234/draft-next/format-assertion-true.json": r"""{
+    "$id": "http://localhost:1234/draft-next/format-assertion-true.json",
+    "$schema": "https://json-schema.org/draft/next/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/core": true,
+        "https://json-schema.org/draft/next/vocab/format-assertion": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/core" },
+        { "$ref": "https://json-schema.org/draft/next/schema/meta/format-assertion" }
+    ]
+}
+""",
+  "http://localhost:1234/draft-next/metaschema-no-validation.json": r"""{
+    "$id": "http://localhost:1234/draft-next/metaschema-no-validation.json",
+    "$vocabulary": {
+        "https://json-schema.org/draft/next/vocab/applicator": true,
+        "https://json-schema.org/draft/next/vocab/core": true
+    },
+    "allOf": [
+        { "$ref": "https://json-schema.org/draft/next/meta/applicator" },
+        { "$ref": "https://json-schema.org/draft/next/meta/core" }
+    ]
+}
+""",
   "http://localhost:1234/draft2019-09/metaschema-no-validation.json": r"""{
     "$id": "http://localhost:1234/draft2019-09/metaschema-no-validation.json",
     "$vocabulary": {

--- a/test/unit/specification_tests.dart
+++ b/test/unit/specification_tests.dart
@@ -6207,7 +6207,7 @@ Map<String, String> specificationTests = {
         "description": "schema that uses custom metaschema with format-assertion: false",
         "schema": {
             "$id": "https://schema/using/format-assertion/false",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-false.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-false.json",
             "format": "ipv4"
         },
         "tests": [
@@ -6227,7 +6227,7 @@ Map<String, String> specificationTests = {
         "description": "schema that uses custom metaschema with format-assertion: true",
         "schema": {
             "$id": "https://schema/using/format-assertion/true",
-            "$schema": "http://localhost:1234/draft2020-12/format-assertion-true.json",
+            "$schema": "http://localhost:1234/draft-next/format-assertion-true.json",
             "format": "ipv4"
         },
         "tests": [
@@ -13044,7 +13044,7 @@ Map<String, String> specificationTests = {
         "description": "schema that uses custom metaschema with with no validation vocabulary",
         "schema": {
             "$id": "https://schema/using/no/validation",
-            "$schema": "http://localhost:1234/draft2020-12/metaschema-no-validation.json",
+            "$schema": "http://localhost:1234/draft-next/metaschema-no-validation.json",
             "properties": {
                 "badProperty": false,
                 "numberProperty": {
@@ -20671,6 +20671,50 @@ Map<String, String> specificationTests = {
                 "description": "non-ascii digits should be rejected",
                 "data": "1২:00:00Z",
                 "valid": false
+            }
+        ]
+    }
+]
+""",
+  "/draft2019-09/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
             }
         ]
     }
@@ -33801,6 +33845,50 @@ Map<String, String> specificationTests = {
     }
 ]
 """,
+  "/draft2020-12/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]
+""",
   "/draft2020-12/optional/format/uri-reference.json": r"""[
     {
         "description": "validation of URI References",
@@ -46320,6 +46408,50 @@ Map<String, String> specificationTests = {
     }
 ]
 """,
+  "/draft4/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
+            }
+        ]
+    }
+]
+""",
   "/draft4/optional/format/uri.json": r"""[
     {
         "description": "validation of URIs",
@@ -49858,27 +49990,6 @@ Map<String, String> specificationTests = {
             {
                 "description": "matches neither items nor contains",
                 "data": [ 1, 5 ],
-                "valid": false
-            }
-        ]
-    },
-    {
-        "description": "contains with false if subschema",
-        "schema": {
-            "contains": {
-                "if": false,
-                "else": true
-            }
-        },
-        "tests": [
-            {
-                "description": "any non-empty array is valid",
-                "data": ["foo"],
-                "valid": true
-            },
-            {
-                "description": "empty array is invalid",
-                "data": [],
                 "valid": false
             }
         ]
@@ -53485,6 +53596,50 @@ Map<String, String> specificationTests = {
                 "description": "not a valid JSON-pointer (isn't empty nor starts with /) #3",
                 "data": "a/a",
                 "valid": false
+            }
+        ]
+    }
+]
+""",
+  "/draft6/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
             }
         ]
     }
@@ -62858,6 +63013,50 @@ Map<String, String> specificationTests = {
                 "description": "non-ascii digits should be rejected",
                 "data": "1২:00:00Z",
                 "valid": false
+            }
+        ]
+    }
+]
+""",
+  "/draft7/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
             }
         ]
     }
@@ -73686,6 +73885,50 @@ Map<String, String> specificationTests = {
                 "description": "non-ascii digits should be rejected",
                 "data": "1২:00:00Z",
                 "valid": false
+            }
+        ]
+    }
+]
+""",
+  "/latest/optional/format/unknown.json": r"""[
+    {
+        "description": "unknown format",
+        "schema": { "format": "unknown" },
+        "tests": [
+            {
+                "description": "unknown formats ignore integers",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore floats",
+                "data": 13.7,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore objects",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore booleans",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore nulls",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "unknown formats ignore strings",
+                "data": "string",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
## Ultimate problem:
We always like to test against the most recent [spec tests](https://github.com/json-schema-org/JSON-Schema-Test-Suite). 

## How it was fixed:
Particularly with Draft 2019 support nearing feature-completion, let's update again.

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf