### PR TITLE
Switch subschema inlining to use $defs

### DIFF
--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -669,17 +669,15 @@ class JsonSchemaDefinitions {
         "https://json-schema.org/draft/2019-09/vocab/content": true
     },
     "$recursiveAnchor": true,
-
+    "allOf": [
+      {"$ref": "#/$defs/vocab-applicator"},
+      {"$ref": "#/$defs/vocab-content"},
+      {"$ref": "#/$defs/vocab-core"},
+      {"$ref": "#/$defs/vocab-format"},
+      {"$ref": "#/$defs/vocab-metadata"},
+      {"$ref": "#/$defs/vocab-validation"}
+    ],
     "title": "Core and Validation specifications meta-schema",
-    "allOf": [''' +
-      '''${Draft2019Subschemas.applicator},
-         ${Draft2019Subschemas.content},
-         ${Draft2019Subschemas.core},
-         ${Draft2019Subschemas.format},
-         ${Draft2019Subschemas.metadata},
-         ${Draft2019Subschemas.validation}
-    ],''' +
-      r'''
     "type": ["object", "boolean"],
     "properties": {
         "definitions": {
@@ -698,6 +696,15 @@ class JsonSchemaDefinitions {
                 ]
             }
         }
+    },
+    "$defs": {''' +
+      '''
+      "vocab-applicator": ${Draft2019Subschemas.applicator},
+      "vocab-content": ${Draft2019Subschemas.content},
+      "vocab-core": ${Draft2019Subschemas.core},
+      "vocab-format": ${Draft2019Subschemas.format},
+      "vocab-metadata": ${Draft2019Subschemas.metadata},
+      "vocab-validation": ${Draft2019Subschemas.validation}
     }
 }
   ''';


### PR DESCRIPTION
## Ultimate problem:
https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.1 recommends that `$ref` removal be done using `$def`s.

## How it was fixed:
Do it that way instead

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf