### PR TITLE
RM-124999 Release json_schema 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+* Remove the need for separate browser and VM imports
+* Deprecate non-json RefProviders
+* More specific missing-required property errors
+
 ## 3.0.0
 
 * Removed support for Dart 1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 3.0.1
+version: 3.1.0
 description: Provide support for validating instances against json schema
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Raise Max Versions](https://github.com/Workiva/json_schema/pull/84)
	* [Migrate to GitHub actions](https://github.com/Workiva/json_schema/pull/85)
	* [chore(package): switch to a json pointer lib that has null safety](https://github.com/Workiva/json_schema/pull/86)
	* [fix(package): don't depend on dart_dev](https://github.com/Workiva/json_schema/pull/87)
	* [feat(package): remove the need for separate vm and browser imports, upgrade deps](https://github.com/Workiva/json_schema/pull/89)
	* [imp(package): use standardized object comparison](https://github.com/Workiva/json_schema/pull/90)
	* [imp(package): deprecate schema providers, rename top-level factories](https://github.com/Workiva/json_schema/pull/91)
	* [chore(package): update standard spec tests ](https://github.com/Workiva/json_schema/pull/92)
	* [feat(package): run all tests on all platforms, add more format tests, logger cleanup](https://github.com/Workiva/json_schema/pull/93)
	* [imp(validator): expose two errors for missing properties, one for the root object path, as well as the property itself](https://github.com/Workiva/json_schema/pull/94)
	* [Update to latest JSON-Schema-Test-Suite](https://github.com/Workiva/json_schema/pull/109)


Requested by: @michaelcarter-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/3.0.1...Workiva:release_json_schema_3.1.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/3.0.1...3.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?pull_number=113&repo_name=Workiva%2Fjson_schema)