### PR TITLE
Add validateWithResults, deprecate validate

### DIFF
--- a/example/from_json/movie_sample.dart
+++ b/example/from_json/movie_sample.dart
@@ -38,6 +38,7 @@
 //     THE SOFTWARE.
 
 import 'package:json_schema/json_schema.dart';
+import 'package:json_schema/src/json_schema/validator.dart';
 
 main() {
   //////////////////////////////////////////////////////////////////////
@@ -77,11 +78,13 @@ main() {
 
   JsonSchema.createAsync(movieSchema).then((schema) {
     final validator = Validator(schema);
-    final bool validates = validator.validate(movies, reportMultipleErrors: true, treatWarningsAsErrors: true);
+    final ValidationResults result = validator.validateWithResults(movies, reportMultipleErrors: true);
 
-    if (!validates) {
-      print('Warnings: ${validator.warnings}');
-      print('Errors: ${validator.errors}');
+    if (result.warnings.isNotEmpty) {
+      print('Warnings: ${result.warnings}');
+    }
+    if (result.errors.isNotEmpty) {
+      print('Errors: ${result.errors}');
     } else {
       print('$movies:\nvalidates!');
     }

--- a/example/from_json/validate_json_from_data.dart
+++ b/example/from_json/validate_json_from_data.dart
@@ -50,8 +50,8 @@ main() {
   final str = 'hi';
 
   JsonSchema.createAsync(mustBeIntegerSchema).then((schema) {
-    print('$n => ${schema.validate(n)}');
-    print('$decimals => ${schema.validate(decimals)}');
-    print('$str => ${schema.validate(str)}');
+    print('$n => ${schema.validateWithResults(n)}');
+    print('$decimals => ${schema.validateWithResults(decimals)}');
+    print('$str => ${schema.validateWithResults(str)}');
   });
 }

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -49,11 +49,11 @@ main() {
   JsonSchema.createFromUrl(url).then((JsonSchema schema) {
     final validSchema = {'type': 'integer'};
     print('''Does schema validate valid schema $validSchema?
-  ${schema.validate(validSchema)}''');
+  ${schema.validateWithResults(validSchema)}''');
 
     final invalidSchema = {'type': 'nibble'};
     print('''Does schema validate invalid schema $invalidSchema?
-  ${schema.validate(invalidSchema)}''');
+  ${schema.validateWithResults(invalidSchema)}''');
   });
 
   //////////////////////////////////////////////////////////////////////
@@ -87,6 +87,6 @@ main() {
 }''');
 
     print('''Does grades schema validate $grades
-  ${schema.validate(grades)}''');
+  ${schema.validateWithResults(grades)}''');
   });
 }

--- a/example/readme/asynchronous_creation/from_file.dart
+++ b/example/readme/asynchronous_creation/from_file.dart
@@ -57,8 +57,8 @@ main() async {
     'longitude': 7836,
   };
 
-  print('$workivaAmes => ${schema.validate(workivaAmes)}'); // true
-  print('$nowhereville => ${schema.validate(nowhereville)}'); // false
+  print('$workivaAmes => ${schema.validateWithResults(workivaAmes)}'); // valid
+  print('$nowhereville => ${schema.validateWithResults(nowhereville)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/from_url.dart
+++ b/example/readme/asynchronous_creation/from_url.dart
@@ -51,9 +51,9 @@ main() async {
   final decimals = 3.14;
   final str = 'hi';
 
-  print('$n => ${schema.validate(n)}'); // true
-  print('$decimals => ${schema.validate(decimals)}'); // false
-  print('$str => ${schema.validate(str)}'); // false
+  print('$n => ${schema.validateWithResults(n)}'); // valid
+  print('$decimals => ${schema.validateWithResults(decimals)}'); // invalid
+  print('$str => ${schema.validateWithResults(str)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/remote_http_refs.dart
+++ b/example/readme/asynchronous_creation/remote_http_refs.dart
@@ -57,9 +57,9 @@ main() async {
   final decimalsArray = [3.14, 1.2, 5.8];
   final strArray = ['hello', 'world'];
 
-  print('$numbersArray => ${schema.validate(numbersArray)}'); // true
-  print('$decimalsArray => ${schema.validate(decimalsArray)}'); // false
-  print('$strArray => ${schema.validate(strArray)}'); // false
+  print('$numbersArray => ${schema.validateWithResults(numbersArray)}'); // valid
+  print('$decimalsArray => ${schema.validateWithResults(decimalsArray)}'); // invalid
+  print('$strArray => ${schema.validateWithResults(strArray)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/remote_ref_cache.dart
+++ b/example/readme/asynchronous_creation/remote_ref_cache.dart
@@ -105,8 +105,8 @@ main() async {
     }
   ];
 
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+  print('${json.encode(workivaLocations)} => ${schema.validateWithResults(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validateWithResults(badLocations)}');
 
   exit(0);
 }

--- a/example/readme/synchronous_creation/local_ref_cache.dart
+++ b/example/readme/synchronous_creation/local_ref_cache.dart
@@ -99,6 +99,6 @@ main() {
     }
   ];
 
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+  print('${json.encode(workivaLocations)} => ${schema.validateWithResults(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validateWithResults(badLocations)}');
 }

--- a/example/readme/synchronous_creation/self_contained.dart
+++ b/example/readme/synchronous_creation/self_contained.dart
@@ -51,7 +51,7 @@ main() {
   // Construct the schema from the schema map or JSON string.
   final schema = JsonSchema.create(mustBeIntegerSchemaMap);
 
-  print('$n => ${schema.validate(n)}'); // true
-  print('$decimals => ${schema.validate(decimals)}'); // false
-  print('$str => ${schema.validate(str)}'); // false
+  print('$n => ${schema.validateWithResults(n)}'); // valid
+  print('$decimals => ${schema.validateWithResults(decimals)}'); // invalid
+  print('$str => ${schema.validateWithResults(str)}'); // invalid
 }

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1558,29 +1558,21 @@ class JsonSchema {
 
   /// Validate [instance] against this schema, returning a boolean indicating whether
   /// validation succeeded or failed.
-  bool validate(dynamic instance,
-          {bool reportMultipleErrors = false,
-          bool parseJson = false,
-          bool validateFormats,
-          bool treatWarningsAsErrors = false}) =>
-      Validator(this).validate(instance,
-          reportMultipleErrors: reportMultipleErrors,
-          parseJson: parseJson,
-          validateFormats: validateFormats,
-          treatWarningsAsErrors: treatWarningsAsErrors);
+  @Deprecated("Use validateWithResults instead")
+  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false, bool validateFormats}) =>
+      this.validateWithResults(instance, parseJson: parseJson, validateFormats: validateFormats).errors.isEmpty;
 
   /// Validate [instance] against this schema, returning a list of [ValidationError]
   /// objects with information about any validation errors that occurred.
-  List<ValidationError> validateWithErrors(dynamic instance,
-      {bool parseJson = false, bool validateFormats, bool treatWarningsAsErrors = false}) {
-    final validator = Validator(this);
-    validator.validate(instance,
-        reportMultipleErrors: true,
-        parseJson: parseJson,
-        validateFormats: validateFormats,
-        treatWarningsAsErrors: treatWarningsAsErrors);
-    return treatWarningsAsErrors ? validator.errorObjects + validator.warningObjects : validator.errorObjects;
-  }
+  @Deprecated("Use validateWithResults instead")
+  List<ValidationError> validateWithErrors(dynamic instance, {bool parseJson = false, bool validateFormats}) =>
+      this.validateWithResults(instance, parseJson: parseJson, validateFormats: validateFormats).errors;
+
+  /// Validate [instance] against this schema, returning the result
+  /// with information about any validation errors or warnings that occurred.
+  ValidationResults validateWithResults(dynamic instance, {bool parseJson = false, bool validateFormats}) =>
+      Validator(this).validateWithResults(instance,
+          reportMultipleErrors: true, parseJson: parseJson, validateFormats: validateFormats);
 
   // --------------------------------------------------------------------------
   // JSON Schema Internal Operations

--- a/test/unit/json_schema/configurable_format_validation_test.dart
+++ b/test/unit/json_schema/configurable_format_validation_test.dart
@@ -17,14 +17,10 @@ main() {
 
     final badlyFormatted = {'someKey': '@@@@@'};
 
-    expect(schemaDraft7.validate(badlyFormatted), isFalse);
-    expect(schemaDraft7.validate(badlyFormatted, validateFormats: false), isTrue);
-    expect(schemaDraft7.validateWithErrors(badlyFormatted), isNotEmpty);
-    expect(schemaDraft7.validateWithErrors(badlyFormatted, validateFormats: false), isEmpty);
+    expect(schemaDraft7.validateWithResults(badlyFormatted).errors.isEmpty, isFalse);
+    expect(schemaDraft7.validateWithResults(badlyFormatted, validateFormats: false).errors.isEmpty, isTrue);
 
-    expect(schemaDraft2019.validate(badlyFormatted), isTrue);
-    expect(schemaDraft2019.validate(badlyFormatted, validateFormats: true), isFalse);
-    expect(schemaDraft2019.validateWithErrors(badlyFormatted), isEmpty);
-    expect(schemaDraft2019.validateWithErrors(badlyFormatted, validateFormats: true), isNotEmpty);
+    expect(schemaDraft2019.validateWithResults(badlyFormatted).errors.isEmpty, isTrue);
+    expect(schemaDraft2019.validateWithResults(badlyFormatted, validateFormats: true).errors.isEmpty, isFalse);
   });
 }

--- a/test/unit/json_schema/nested_refs_in_root_schema_test.dart
+++ b/test/unit/json_schema/nested_refs_in_root_schema_test.dart
@@ -12,9 +12,8 @@ main() {
         "required": ["foo", "bar"]
       });
 
-      final isValid = barSchema.validate({"foo": 2, "bar": "test"});
-
-      final isInvalid = barSchema.validate({"foo": 2, "bar": 4});
+      final isValid = barSchema.validateWithResults({"foo": 2, "bar": "test"}).errors.isEmpty;
+      final isInvalid = barSchema.validateWithResults({"foo": 2, "bar": 4}).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -25,8 +24,8 @@ main() {
         "items": {"\$ref": "http://localhost:1234/integer.json"}
       });
 
-      final isValid = schema.validate([1, 2, 3, 4]);
-      final isInvalid = schema.validate([1, 2, 3, '4']);
+      final isValid = schema.validateWithResults([1, 2, 3, 4]).errors.isEmpty;
+      final isInvalid = schema.validateWithResults([1, 2, 3, '4']).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -44,8 +43,8 @@ main() {
         }
       });
 
-      final isValid = schema.validate([3.4]);
-      final isInvalid = schema.validate(['test']);
+      final isValid = schema.validateWithResults([3.4]).errors.isEmpty;
+      final isInvalid = schema.validateWithResults(['test']).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -90,33 +89,39 @@ main() {
       refProvider: syncRefJsonProvider,
     );
 
-    final isValid = schema.validate({
-      "meta": "a string",
-      "nodes": [
-        {
-          "value": 123,
-          "subtree": {"meta": "a string", "nodes": []}
-        }
-      ]
-    });
+    final isValid = schema
+        .validateWithResults({
+          "meta": "a string",
+          "nodes": [
+            {
+              "value": 123,
+              "subtree": {"meta": "a string", "nodes": []}
+            }
+          ]
+        })
+        .errors
+        .isEmpty;
 
-    final isInvalid = schema.validate({
-      "meta": "a string",
-      "nodes": [
-        {
-          "value": 123,
-          "subtree": {
-            "meta": "a string",
-            "nodes": [
-              {
-                "value": 123,
-                "subtree": {"meta": 123, "nodes": []}
+    final isInvalid = schema
+        .validateWithResults({
+          "meta": "a string",
+          "nodes": [
+            {
+              "value": 123,
+              "subtree": {
+                "meta": "a string",
+                "nodes": [
+                  {
+                    "value": 123,
+                    "subtree": {"meta": 123, "nodes": []}
+                  }
+                ]
               }
-            ]
-          }
-        }
-      ]
-    });
+            }
+          ]
+        })
+        .errors
+        .isEmpty;
 
     expect(isValid, isTrue);
     expect(isInvalid, isFalse);

--- a/test/unit/json_schema/relative_file_uri_test.dart
+++ b/test/unit/json_schema/relative_file_uri_test.dart
@@ -9,8 +9,8 @@ main() {
     // this assumes that tests are run from the root directory of the project
     final schema = await JsonSchema.createFromUrl('test/relative_refs/root.json');
 
-    expect(schema.validate({"string": 123, "integer": 123}), isFalse);
-    expect(schema.validate({"string": "a string", "integer": "a string"}), isFalse);
-    expect(schema.validate({"string": "a string", "integer": 123}), isTrue);
+    expect(schema.validateWithResults({"string": 123, "integer": 123}).errors.isEmpty, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": "a string"}).errors.isEmpty, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": 123}).errors.isEmpty, isTrue);
   });
 }

--- a/test/unit/json_schema/schema_self_validation.dart
+++ b/test/unit/json_schema/schema_self_validation.dart
@@ -47,7 +47,7 @@ void main() {
         // that the schema satisfies the schema for schemas.
         final url = version;
         JsonSchema.createFromUrl(url).then(expectAsync1((schema) {
-          expect(schema.validate(schema.schemaMap), isTrue);
+          expect(schema.validateWithResults(schema.schemaMap).errors.isEmpty, isTrue);
         }));
       });
     }

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -427,7 +427,7 @@ void main() {
     test('Unknown format', () {
       final schema = createObjectSchema({'format': 'fake-format'});
 
-      final isValid = schema.validate({'someKey': '3'});
+      final isValid = schema.validateWithResults({'someKey': '3'}).errors.isEmpty;
 
       expect(isValid, isTrue);
     });


### PR DESCRIPTION
## Ultimate problem:
Our existing `validate` and `validateWithErrors` would be better as a `validateWithResults` method that is able to return warning errors, annotations, standard outputs, etc. to the caller. What the caller does with that information is up to them.

While I'm at it, remove the `treatWarningsAsErrors` option. That's now up to the caller.

## How it was fixed:
Add it and deprecate the old ones. We'll leave them around for now to make upgrading to the new major easier.

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf