### PR TITLE
Add validateWithResults, Deprecate Preexisting

### DIFF
--- a/example/from_json/movie_sample.dart
+++ b/example/from_json/movie_sample.dart
@@ -78,12 +78,7 @@ main() {
 
   JsonSchema.createAsync(movieSchema).then((schema) {
     final validator = Validator(schema);
-    final ValidationResults result = validator.validateWithResults(movies, reportMultipleErrors: true);
-
-    if (result.errors.isNotEmpty) {
-      print('Errors: ${result.errors}');
-    } else {
-      print('$movies:\nvalidates!');
-    }
+    final ValidationResults results = validator.validateWithResults(movies, reportMultipleErrors: true);
+    print('$movies:\n$results');
   });
 }

--- a/example/from_json/movie_sample.dart
+++ b/example/from_json/movie_sample.dart
@@ -38,6 +38,7 @@
 //     THE SOFTWARE.
 
 import 'package:json_schema/json_schema.dart';
+import 'package:json_schema/src/json_schema/validator.dart';
 
 main() {
   //////////////////////////////////////////////////////////////////////
@@ -77,9 +78,10 @@ main() {
 
   JsonSchema.createAsync(movieSchema).then((schema) {
     final validator = Validator(schema);
-    final bool validates = validator.validate(movies);
-    if (!validates) {
-      print('Errors: ${validator.errors}');
+    final ValidationResults result = validator.validateWithResults(movies, reportMultipleErrors: true);
+
+    if (result.errors.isNotEmpty) {
+      print('Errors: ${result.errors}');
     } else {
       print('$movies:\nvalidates!');
     }

--- a/example/from_json/movie_sample.dart
+++ b/example/from_json/movie_sample.dart
@@ -38,7 +38,6 @@
 //     THE SOFTWARE.
 
 import 'package:json_schema/json_schema.dart';
-import 'package:json_schema/src/json_schema/validator.dart';
 
 main() {
   //////////////////////////////////////////////////////////////////////
@@ -78,7 +77,7 @@ main() {
 
   JsonSchema.createAsync(movieSchema).then((schema) {
     final validator = Validator(schema);
-    final ValidationResults results = validator.validateWithResults(movies, reportMultipleErrors: true);
+    final results = validator.validateWithResults(movies, reportMultipleErrors: true);
     print('$movies:\n$results');
   });
 }

--- a/example/from_json/validate_json_from_data.dart
+++ b/example/from_json/validate_json_from_data.dart
@@ -50,8 +50,8 @@ main() {
   final str = 'hi';
 
   JsonSchema.createAsync(mustBeIntegerSchema).then((schema) {
-    print('$n => ${schema.validate(n)}');
-    print('$decimals => ${schema.validate(decimals)}');
-    print('$str => ${schema.validate(str)}');
+    print('$n => ${schema.validateWithResults(n)}');
+    print('$decimals => ${schema.validateWithResults(decimals)}');
+    print('$str => ${schema.validateWithResults(str)}');
   });
 }

--- a/example/from_url/validate_instance_from_url.dart
+++ b/example/from_url/validate_instance_from_url.dart
@@ -49,11 +49,11 @@ main() {
   JsonSchema.createFromUrl(url).then((JsonSchema schema) {
     final validSchema = {'type': 'integer'};
     print('''Does schema validate valid schema $validSchema?
-  ${schema.validate(validSchema)}''');
+  ${schema.validateWithResults(validSchema)}''');
 
     final invalidSchema = {'type': 'nibble'};
     print('''Does schema validate invalid schema $invalidSchema?
-  ${schema.validate(invalidSchema)}''');
+  ${schema.validateWithResults(invalidSchema)}''');
   });
 
   //////////////////////////////////////////////////////////////////////
@@ -87,6 +87,6 @@ main() {
 }''');
 
     print('''Does grades schema validate $grades
-  ${schema.validate(grades)}''');
+  ${schema.validateWithResults(grades)}''');
   });
 }

--- a/example/readme/asynchronous_creation/from_file.dart
+++ b/example/readme/asynchronous_creation/from_file.dart
@@ -57,8 +57,8 @@ main() async {
     'longitude': 7836,
   };
 
-  print('$workivaAmes => ${schema.validate(workivaAmes)}'); // true
-  print('$nowhereville => ${schema.validate(nowhereville)}'); // false
+  print('$workivaAmes => ${schema.validateWithResults(workivaAmes)}'); // valid
+  print('$nowhereville => ${schema.validateWithResults(nowhereville)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/from_url.dart
+++ b/example/readme/asynchronous_creation/from_url.dart
@@ -51,9 +51,9 @@ main() async {
   final decimals = 3.14;
   final str = 'hi';
 
-  print('$n => ${schema.validate(n)}'); // true
-  print('$decimals => ${schema.validate(decimals)}'); // false
-  print('$str => ${schema.validate(str)}'); // false
+  print('$n => ${schema.validateWithResults(n)}'); // valid
+  print('$decimals => ${schema.validateWithResults(decimals)}'); // invalid
+  print('$str => ${schema.validateWithResults(str)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/remote_http_refs.dart
+++ b/example/readme/asynchronous_creation/remote_http_refs.dart
@@ -57,9 +57,9 @@ main() async {
   final decimalsArray = [3.14, 1.2, 5.8];
   final strArray = ['hello', 'world'];
 
-  print('$numbersArray => ${schema.validate(numbersArray)}'); // true
-  print('$decimalsArray => ${schema.validate(decimalsArray)}'); // false
-  print('$strArray => ${schema.validate(strArray)}'); // false
+  print('$numbersArray => ${schema.validateWithResults(numbersArray)}'); // valid
+  print('$decimalsArray => ${schema.validateWithResults(decimalsArray)}'); // invalid
+  print('$strArray => ${schema.validateWithResults(strArray)}'); // invalid
 
   // Exit the process cleanly (VM Only).
   exit(0);

--- a/example/readme/asynchronous_creation/remote_ref_cache.dart
+++ b/example/readme/asynchronous_creation/remote_ref_cache.dart
@@ -105,8 +105,8 @@ main() async {
     }
   ];
 
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+  print('${json.encode(workivaLocations)} => ${schema.validateWithResults(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validateWithResults(badLocations)}');
 
   exit(0);
 }

--- a/example/readme/synchronous_creation/local_ref_cache.dart
+++ b/example/readme/synchronous_creation/local_ref_cache.dart
@@ -99,6 +99,6 @@ main() {
     }
   ];
 
-  print('${json.encode(workivaLocations)} => ${schema.validate(workivaLocations)}');
-  print('${json.encode(badLocations)} => ${schema.validate(badLocations)}');
+  print('${json.encode(workivaLocations)} => ${schema.validateWithResults(workivaLocations)}');
+  print('${json.encode(badLocations)} => ${schema.validateWithResults(badLocations)}');
 }

--- a/example/readme/synchronous_creation/self_contained.dart
+++ b/example/readme/synchronous_creation/self_contained.dart
@@ -51,7 +51,7 @@ main() {
   // Construct the schema from the schema map or JSON string.
   final schema = JsonSchema.create(mustBeIntegerSchemaMap);
 
-  print('$n => ${schema.validate(n)}'); // true
-  print('$decimals => ${schema.validate(decimals)}'); // false
-  print('$str => ${schema.validate(str)}'); // false
+  print('$n => ${schema.validateWithResults(n)}'); // valid
+  print('$decimals => ${schema.validateWithResults(decimals)}'); // invalid
+  print('$str => ${schema.validateWithResults(str)}'); // invalid
 }

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -77,9 +77,7 @@ class SchemaNode {
   }
 
   String get node {
-    final data = ['"${schema.path}" [']
-      ..add(label.join('\n'))
-      ..add(']');
+    final data = ['"${schema.path}" [']..add(label.join('\n'))..add(']');
     return data.join('\n');
   }
 

--- a/lib/schema_dot.dart
+++ b/lib/schema_dot.dart
@@ -77,7 +77,9 @@ class SchemaNode {
   }
 
   String get node {
-    final data = ['"${schema.path}" [']..add(label.join('\n'))..add(']');
+    final data = ['"${schema.path}" [']
+      ..add(label.join('\n'))
+      ..add(']');
     return data.join('\n');
   }
 

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1427,17 +1427,25 @@ class JsonSchema {
 
   /// Validate [instance] against this schema, returning a boolean indicating whether
   /// validation succeeded or failed.
+  @Deprecated("Use validateWithResults instead")
   bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false, bool validateFormats}) =>
       Validator(this).validate(instance,
           reportMultipleErrors: reportMultipleErrors, parseJson: parseJson, validateFormats: validateFormats);
 
   /// Validate [instance] against this schema, returning a list of [ValidationError]
   /// objects with information about any validation errors that occurred.
+  @Deprecated("Use validateWithResults instead")
   List<ValidationError> validateWithErrors(dynamic instance, {bool parseJson = false, bool validateFormats}) {
     final validator = Validator(this);
     validator.validate(instance, reportMultipleErrors: true, parseJson: parseJson, validateFormats: validateFormats);
     return validator.errorObjects;
   }
+
+  /// Validate [instance] against this schema, returning the result
+  /// with information about any validation errors or warnings that occurred.
+  ValidationResults validateWithResults(dynamic instance, {bool parseJson = false, bool validateFormats}) =>
+      Validator(this).validateWithResults(instance,
+          reportMultipleErrors: true, parseJson: parseJson, validateFormats: validateFormats);
 
   // --------------------------------------------------------------------------
   // JSON Schema Internal Operations

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -67,11 +67,7 @@ class Instance {
 class ValidationResults {
   ValidationResults(List<ValidationError> errors) {
     this.errors = List.of(errors ?? []);
-    this.isValid = errors == null || errors.isEmpty;
   }
-
-  /// Whether the [Instance] was valid against its [JsonSchema]
-  bool isValid;
 
   /// Correctness issues discovered by validation.
   List<ValidationError> errors;
@@ -80,6 +76,9 @@ class ValidationResults {
   String toString() {
     return isValid ? 'VALID' : 'INVALID, Errors: ${errors}';
   }
+
+  /// Whether the [Instance] was valid against its [JsonSchema]
+  bool get isValid => errors.isEmpty;
 }
 
 class ValidationError {

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -65,12 +65,10 @@ class Instance {
 
 /// The result of validating data against a schema
 class ValidationResults {
-  ValidationResults(List<ValidationError> errors) {
-    this.errors = List.of(errors ?? []);
-  }
+  ValidationResults(List<ValidationError> errors) : errors = List.of(errors ?? []);
 
   /// Correctness issues discovered by validation.
-  List<ValidationError> errors;
+  final List<ValidationError> errors;
 
   @override
   String toString() {

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -63,6 +63,21 @@ class Instance {
   toString() => data.toString();
 }
 
+/// The result of validating data against a schema
+class ValidationResults {
+  ValidationResults(errors) {
+    this.errors = List.of(errors);
+  }
+
+  /// Correctness issues discovered by validation.
+  List<ValidationError> errors = [];
+
+  @override
+  String toString() {
+    return '${errors.isEmpty ? 'VALID' : 'INVALID'}${errors.isEmpty ? ', Errors: ${errors}' : ''}';
+  }
+}
+
 class ValidationError {
   ValidationError._(this.instancePath, this.schemaPath, this.message);
 
@@ -83,14 +98,17 @@ class ValidationError {
 class Validator {
   Validator(this._rootSchema);
 
+  @Deprecated('Use validateWithResults and ValidationResults.errors.map((e) => e.toString()).toList() instead')
   List<String> get errors => _errors.map((e) => e.toString()).toList();
 
+  @Deprecated('Use validateWithResults and ValidationResults.errors instead')
   List<ValidationError> get errorObjects => _errors;
 
   bool _validateFormats;
 
   /// Validate the [instance] against the this validator's schema
-  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false, bool validateFormats}) {
+  ValidationResults validateWithResults(dynamic instance,
+      {bool reportMultipleErrors = false, bool parseJson = false, bool validateFormats}) {
     if (validateFormats == null) {
       // Reference: https://json-schema.org/draft/2019-09/release-notes.html#format-vocabulary
       if ([SchemaVersion.draft4, SchemaVersion.draft6, SchemaVersion.draft7].contains(_rootSchema.schemaVersion)) {
@@ -117,17 +135,26 @@ class Validator {
     if (!_reportMultipleErrors) {
       try {
         _validate(_rootSchema, data);
-        return true;
+        return ValidationResults(_errors);
       } on FormatException {
-        return false;
+        return ValidationResults(_errors);
       } catch (e) {
         _logger.shout('Unexpected Exception: $e');
-        return false;
+        return null;
       }
     }
 
     _validate(_rootSchema, data);
-    return _errors.isEmpty;
+    return ValidationResults(_errors);
+  }
+
+  /// Validate the [instance] against the this validator's schema
+  @Deprecated('Use validateWithResults instead')
+  bool validate(dynamic instance, {bool reportMultipleErrors = false, bool parseJson = false, bool validateFormats}) {
+    return validateWithResults(instance,
+            reportMultipleErrors: reportMultipleErrors, parseJson: parseJson, validateFormats: validateFormats)
+        .errors
+        .isEmpty;
   }
 
   static bool _typeMatch(SchemaType type, JsonSchema schema, dynamic instance) {
@@ -292,14 +319,14 @@ class Validator {
     }
 
     if (schema.contains != null) {
-      if (!instance.data.any((item) => Validator(schema.contains).validate(item))) {
+      if (!instance.data.any((item) => Validator(schema.contains).validateWithResults(item).errors.isEmpty)) {
         _err('contains violated: $instance', instance.path, schema.path);
       }
     }
   }
 
   void _validateAllOf(JsonSchema schema, Instance instance) {
-    if (!schema.allOf.every((s) => Validator(s).validate(instance))) {
+    if (!schema.allOf.every((s) => Validator(s).validateWithResults(instance).errors.isEmpty)) {
       _err('${schema.path}: allOf violated ${instance}', instance.path, schema.path + '/allOf');
     }
   }
@@ -321,7 +348,7 @@ class Validator {
   }
 
   void _validateNot(JsonSchema schema, Instance instance) {
-    if (Validator(schema.notSchema).validate(instance)) {
+    if (Validator(schema.notSchema).validateWithResults(instance).errors.isEmpty) {
       // TODO: deal with .notSchema
       _err('${schema.notSchema.path}: not violated', instance.path, schema.notSchema.path);
     }
@@ -512,7 +539,7 @@ class Validator {
   void _schemaDependenciesValidation(JsonSchema schema, Instance instance) {
     schema.schemaDependencies.forEach((k, otherSchema) {
       if (instance.data.containsKey(k)) {
-        if (!Validator(otherSchema).validate(instance)) {
+        if (Validator(otherSchema).validateWithResults(instance).errors.isNotEmpty) {
           _err('prop $k violated schema dependency', instance.path, otherSchema.path);
         }
       }
@@ -589,7 +616,7 @@ class Validator {
       // Bail out early if no 'then' or 'else' schemas exist.
       if (schema.thenSchema == null && schema.elseSchema == null) return true;
 
-      if (schema.ifSchema.validate(instance)) {
+      if (schema.ifSchema.validateWithResults(instance).errors.isEmpty) {
         // Bail out early if no "then" is specified.
         if (schema.thenSchema == null) return true;
         if (!Validator(schema.thenSchema).validate(instance)) {

--- a/test/unit/json_schema/configurable_format_validation_test.dart
+++ b/test/unit/json_schema/configurable_format_validation_test.dart
@@ -22,8 +22,10 @@ main() {
 
     expect(errorsFormatsOn, isNotEmpty);
 
-    final errorsFormatsOff =
-        schema.validateWithErrors({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false);
+    final errorsFormatsOff = schema
+        .validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false)
+        .errors
+        .isEmpty;
 
     expect(errorsFormatsOff, isEmpty);
   });

--- a/test/unit/json_schema/configurable_format_validation_test.dart
+++ b/test/unit/json_schema/configurable_format_validation_test.dart
@@ -9,24 +9,28 @@ main() {
       }
     });
 
-    final isValidFormatsOn = schema.validate({'someKey': 'http://example.com/dictionary/{term:1}/{term'});
+    final isValidFormatsOn =
+        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).errors.isEmpty;
 
     expect(isValidFormatsOn, isFalse);
 
-    final isValidFormatsOff =
-        schema.validate({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false);
+    final isValidFormatsOff = schema
+        .validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false)
+        .errors
+        .isEmpty;
 
     expect(isValidFormatsOff, isTrue);
 
-    final errorsFormatsOn = schema.validateWithErrors({'someKey': 'http://example.com/dictionary/{term:1}/{term'});
+    final errorsFormatsOn =
+        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).errors.isEmpty;
 
-    expect(errorsFormatsOn, isNotEmpty);
+    expect(errorsFormatsOn, isFalse);
 
     final errorsFormatsOff = schema
         .validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}, validateFormats: false)
         .errors
         .isEmpty;
 
-    expect(errorsFormatsOff, isEmpty);
+    expect(errorsFormatsOff, isTrue);
   });
 }

--- a/test/unit/json_schema/configurable_format_validation_test.dart
+++ b/test/unit/json_schema/configurable_format_validation_test.dart
@@ -10,7 +10,7 @@ main() {
     });
 
     final isValidFormatsOn =
-        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).errors.isEmpty;
+        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).isValid;
 
     expect(isValidFormatsOn, isFalse);
 
@@ -22,7 +22,7 @@ main() {
     expect(isValidFormatsOff, isTrue);
 
     final errorsFormatsOn =
-        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).errors.isEmpty;
+        schema.validateWithResults({'someKey': 'http://example.com/dictionary/{term:1}/{term'}).isValid;
 
     expect(errorsFormatsOn, isFalse);
 

--- a/test/unit/json_schema/nested_refs_in_root_schema_test.dart
+++ b/test/unit/json_schema/nested_refs_in_root_schema_test.dart
@@ -12,8 +12,8 @@ main() {
         "required": ["foo", "bar"]
       });
 
-      final isValid = barSchema.validateWithResults({"foo": 2, "bar": "test"}).errors.isEmpty;
-      final isInvalid = barSchema.validateWithResults({"foo": 2, "bar": 4}).errors.isEmpty;
+      final isValid = barSchema.validateWithResults({"foo": 2, "bar": "test"}).isValid;
+      final isInvalid = barSchema.validateWithResults({"foo": 2, "bar": 4}).isValid;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -24,8 +24,8 @@ main() {
         "items": {"\$ref": "http://localhost:1234/integer.json"}
       });
 
-      final isValid = schema.validateWithResults([1, 2, 3, 4]).errors.isEmpty;
-      final isInvalid = schema.validateWithResults([1, 2, 3, '4']).errors.isEmpty;
+      final isValid = schema.validateWithResults([1, 2, 3, 4]).isValid;
+      final isInvalid = schema.validateWithResults([1, 2, 3, '4']).isValid;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -43,8 +43,8 @@ main() {
         }
       });
 
-      final isValid = schema.validateWithResults([3.4]).errors.isEmpty;
-      final isInvalid = schema.validateWithResults(['test']).errors.isEmpty;
+      final isValid = schema.validateWithResults([3.4]).isValid;
+      final isInvalid = schema.validateWithResults(['test']).isValid;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);

--- a/test/unit/json_schema/nested_refs_in_root_schema_test.dart
+++ b/test/unit/json_schema/nested_refs_in_root_schema_test.dart
@@ -89,37 +89,33 @@ main() {
       refProvider: syncRefJsonProvider,
     );
 
-    final isValid = schema
-        .validateWithResults({
-          "meta": "a string",
-          "nodes": [
-            {
-              "value": 123,
-              "subtree": {"meta": "a string", "nodes": []}
-            }
-          ]
-        })
-        .isValid;
+    final isValid = schema.validateWithResults({
+      "meta": "a string",
+      "nodes": [
+        {
+          "value": 123,
+          "subtree": {"meta": "a string", "nodes": []}
+        }
+      ]
+    }).isValid;
 
-    final isInvalid = schema
-        .validateWithResults({
-          "meta": "a string",
-          "nodes": [
-            {
-              "value": 123,
-              "subtree": {
-                "meta": "a string",
-                "nodes": [
-                  {
-                    "value": 123,
-                    "subtree": {"meta": 123, "nodes": []}
-                  }
-                ]
+    final isInvalid = schema.validateWithResults({
+      "meta": "a string",
+      "nodes": [
+        {
+          "value": 123,
+          "subtree": {
+            "meta": "a string",
+            "nodes": [
+              {
+                "value": 123,
+                "subtree": {"meta": 123, "nodes": []}
               }
-            }
-          ]
-        })
-        .isValid;
+            ]
+          }
+        }
+      ]
+    }).isValid;
 
     expect(isValid, isTrue);
     expect(isInvalid, isFalse);

--- a/test/unit/json_schema/nested_refs_in_root_schema_test.dart
+++ b/test/unit/json_schema/nested_refs_in_root_schema_test.dart
@@ -12,9 +12,8 @@ main() {
         "required": ["foo", "bar"]
       });
 
-      final isValid = barSchema.validate({"foo": 2, "bar": "test"});
-
-      final isInvalid = barSchema.validate({"foo": 2, "bar": 4});
+      final isValid = barSchema.validateWithResults({"foo": 2, "bar": "test"}).errors.isEmpty;
+      final isInvalid = barSchema.validateWithResults({"foo": 2, "bar": 4}).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -25,8 +24,8 @@ main() {
         "items": {"\$ref": "http://localhost:1234/integer.json"}
       });
 
-      final isValid = schema.validate([1, 2, 3, 4]);
-      final isInvalid = schema.validate([1, 2, 3, '4']);
+      final isValid = schema.validateWithResults([1, 2, 3, 4]).errors.isEmpty;
+      final isInvalid = schema.validateWithResults([1, 2, 3, '4']).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -44,8 +43,8 @@ main() {
         }
       });
 
-      final isValid = schema.validate([3.4]);
-      final isInvalid = schema.validate(['test']);
+      final isValid = schema.validateWithResults([3.4]).errors.isEmpty;
+      final isInvalid = schema.validateWithResults(['test']).errors.isEmpty;
 
       expect(isValid, isTrue);
       expect(isInvalid, isFalse);
@@ -90,33 +89,39 @@ main() {
       refProvider: syncRefJsonProvider,
     );
 
-    final isValid = schema.validate({
-      "meta": "a string",
-      "nodes": [
-        {
-          "value": 123,
-          "subtree": {"meta": "a string", "nodes": []}
-        }
-      ]
-    });
+    final isValid = schema
+        .validateWithResults({
+          "meta": "a string",
+          "nodes": [
+            {
+              "value": 123,
+              "subtree": {"meta": "a string", "nodes": []}
+            }
+          ]
+        })
+        .errors
+        .isEmpty;
 
-    final isInvalid = schema.validate({
-      "meta": "a string",
-      "nodes": [
-        {
-          "value": 123,
-          "subtree": {
-            "meta": "a string",
-            "nodes": [
-              {
-                "value": 123,
-                "subtree": {"meta": 123, "nodes": []}
+    final isInvalid = schema
+        .validateWithResults({
+          "meta": "a string",
+          "nodes": [
+            {
+              "value": 123,
+              "subtree": {
+                "meta": "a string",
+                "nodes": [
+                  {
+                    "value": 123,
+                    "subtree": {"meta": 123, "nodes": []}
+                  }
+                ]
               }
-            ]
-          }
-        }
-      ]
-    });
+            }
+          ]
+        })
+        .errors
+        .isEmpty;
 
     expect(isValid, isTrue);
     expect(isInvalid, isFalse);

--- a/test/unit/json_schema/relative_file_uri_test.dart
+++ b/test/unit/json_schema/relative_file_uri_test.dart
@@ -9,8 +9,8 @@ main() {
     // this assumes that tests are run from the root directory of the project
     final schema = await JsonSchema.createFromUrl('test/relative_refs/root.json');
 
-    expect(schema.validate({"string": 123, "integer": 123}), isFalse);
-    expect(schema.validate({"string": "a string", "integer": "a string"}), isFalse);
-    expect(schema.validate({"string": "a string", "integer": 123}), isTrue);
+    expect(schema.validateWithResults({"string": 123, "integer": 123}).errors.isEmpty, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": "a string"}).errors.isEmpty, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": 123}).errors.isEmpty, isTrue);
   });
 }

--- a/test/unit/json_schema/relative_file_uri_test.dart
+++ b/test/unit/json_schema/relative_file_uri_test.dart
@@ -9,8 +9,8 @@ main() {
     // this assumes that tests are run from the root directory of the project
     final schema = await JsonSchema.createFromUrl('test/relative_refs/root.json');
 
-    expect(schema.validateWithResults({"string": 123, "integer": 123}).errors.isEmpty, isFalse);
-    expect(schema.validateWithResults({"string": "a string", "integer": "a string"}).errors.isEmpty, isFalse);
-    expect(schema.validateWithResults({"string": "a string", "integer": 123}).errors.isEmpty, isTrue);
+    expect(schema.validateWithResults({"string": 123, "integer": 123}).isValid, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": "a string"}).isValid, isFalse);
+    expect(schema.validateWithResults({"string": "a string", "integer": 123}).isValid, isTrue);
   });
 }

--- a/test/unit/json_schema/schema_self_validation.dart
+++ b/test/unit/json_schema/schema_self_validation.dart
@@ -47,7 +47,7 @@ void main() {
         // that the schema satisfies the schema for schemas.
         final url = version;
         JsonSchema.createFromUrl(url).then(expectAsync1((schema) {
-          expect(schema.validate(schema.schemaMap), isTrue);
+          expect(schema.validateWithResults(schema.schemaMap).errors.isEmpty, isTrue);
         }));
       });
     }

--- a/test/unit/json_schema/schema_self_validation.dart
+++ b/test/unit/json_schema/schema_self_validation.dart
@@ -47,7 +47,7 @@ void main() {
         // that the schema satisfies the schema for schemas.
         final url = version;
         JsonSchema.createFromUrl(url).then(expectAsync1((schema) {
-          expect(schema.validateWithResults(schema.schemaMap).errors.isEmpty, isTrue);
+          expect(schema.validateWithResults(schema.schemaMap).isValid, isTrue);
         }));
       });
     }

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -427,7 +427,7 @@ void main() {
     test('Unknown format', () {
       final schema = createObjectSchema({'format': 'fake-format'});
 
-      final isValid = schema.validateWithResults({'someKey': '3'}).errors.isEmpty;
+      final isValid = schema.validateWithResults({'someKey': '3'}).isValid;
 
       expect(isValid, isTrue);
     });

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -427,7 +427,7 @@ void main() {
     test('Unknown format', () {
       final schema = createObjectSchema({'format': 'fake-format'});
 
-      final isValid = schema.validate({'someKey': '3'});
+      final isValid = schema.validateWithResults({'someKey': '3'}).errors.isEmpty;
 
       expect(isValid, isTrue);
     });


### PR DESCRIPTION
## Ultimate problem:
Our existing `validate` and `validateWithErrors` would be better as a `validateWithResults` method that is able to return warning errors, annotations, standard outputs, etc. to the caller. What the caller does with that information is up to them.

## How it was fixed:
Add it and deprecate the old versions. 

## Testing suggestions:
Passing CI

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf