### PR TITLE
RM-130782 Release json_schema 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.2.0
+
+- Add `Validator.validateWithResults` (This new method gives the most complete and customizable validation results)
+- Add `JsonSchema.validateWithResults`
+- Deprecate `JsonSchema.validate`
+- Deprecate `Validator.validate`
+- Deprecate `JsonSchema.validateWithErrors`
+- Deprecate `Validator.errors`
+- Deprecate `Validator.errorObjects`
+
 ## 3.1.0
 
 * Remove the need for separate browser and VM imports

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 3.1.1
+version: 3.2.0
 description: Provide support for validating instances against json schema
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Add validateWithResults, Deprecate Preexisting](https://github.com/Workiva/json_schema/pull/119)


Requested by: @michaelcarter-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/3.1.1...Workiva:release_json_schema_3.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/3.1.1...3.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?pull_number=122&repo_name=Workiva%2Fjson_schema)