### PR TITLE
A failing test example.

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -523,7 +523,8 @@ class JsonSchema {
           }
 
           // If currentSchema is a ref, resolve ref recursively.
-          if (currentSchema.ref != null) {
+          // Cycle detection happens at evaluation time for drafts 2019 and 2020.
+          if (currentSchema.schemaVersion < SchemaVersion.draft2019_09 && currentSchema.ref != null) {
             if (!refsEncountered.add(currentSchema.ref)) {
               // Throw if cycle is detected for currentSchema ref.
               throw FormatException('Failed to get schema at path: "${currentSchema.ref}". Cycle detected.');

--- a/lib/src/json_schema/typedefs.dart
+++ b/lib/src/json_schema/typedefs.dart
@@ -48,3 +48,4 @@ typedef SchemaAssigner = Function(JsonSchema s);
 typedef SchemaAdder = Function(JsonSchema s);
 typedef AsyncRetrievalOperation = Future<JsonSchema> Function();
 typedef SyncRetrievalOperation = JsonSchema Function();
+typedef RefScopeOperation = Function();

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -41,6 +41,7 @@ import 'dart:core';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:json_schema/src/json_schema/typedefs.dart';
 import 'package:logging/logging.dart';
 
 import 'package:json_schema/src/json_schema/constants.dart';
@@ -68,6 +69,23 @@ class Instance {
 
   @override
   int get hashCode => this.path.hashCode;
+}
+
+/// Used for cycle detection when resolving references.
+class _InstanceRefPair {
+  _InstanceRefPair(this.path, this.ref);
+
+  String path;
+  Uri ref;
+
+  @override
+  toString() => "${ref.toString()}: $path";
+
+  @override
+  bool operator ==(Object other) => other is _InstanceRefPair && this.path == other.path && this.ref == other.ref;
+
+  @override
+  int get hashCode => Object.hash(this.path, this.ref);
 }
 
 /// The result of validating data against a schema
@@ -153,7 +171,9 @@ class Validator {
   /// https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.7.1
   ///
   /// This Map keeps track of schemas when a reference is resolved.
-  Map<JsonSchema, JsonSchema> _dynamicParents = Map();
+  Map<JsonSchema, JsonSchema> _dynamicParents = {};
+
+  Set<_InstanceRefPair> _refsEncountered = {};
 
   get evaluatedProperties =>
       _evaluatedPropertiesContext.isNotEmpty ? _evaluatedPropertiesContext.last : Set<Instance>();
@@ -782,6 +802,18 @@ class Validator {
     return lastFound;
   }
 
+  /// A helper function to deal with infinite loops at evaluation time.
+  /// If we see the same data/ref pair twice, we're in a loop.
+  void _withRefScope(Uri refScope, Instance instance, RefScopeOperation fn) {
+    var irp = _InstanceRefPair(instance.path, refScope);
+    if (!_refsEncountered.add(irp)) {
+      // Throw if cycle is detected while evaluating refs.
+      throw FormatException('Cycle detected at path: "${refScope}"');
+    }
+    fn();
+    _refsEncountered.remove(irp);
+  }
+
   void _validate(JsonSchema schema, dynamic instance) {
     if (instance is! Instance) {
       instance = Instance(instance);
@@ -797,10 +829,13 @@ class Validator {
     /// If the [JsonSchema] being validated is a ref, pull the ref
     /// from the [refMap] instead.
     if (schema.ref != null) {
-      var nextSchema = schema.resolvePath(schema.ref);
-      final prevParent = _setDynamicParent(nextSchema, schema);
-      _validate(nextSchema, instance);
-      _setDynamicParent(nextSchema, prevParent);
+      _withRefScope(schema.ref, instance, () {
+        var nextSchema = schema.resolvePath(schema.ref);
+        final prevParent = _setDynamicParent(nextSchema, schema);
+        _validate(nextSchema, instance);
+        _setDynamicParent(nextSchema, prevParent);
+      });
+      // We're not supposed to evaluate other properties in drafts before 2019.
       if (schema.schemaVersion < SchemaVersion.draft2019_09) {
         return;
       }
@@ -809,17 +844,19 @@ class Validator {
     /// If the [JsonSchema] being validated is a recursiveRef, pull the ref
     /// from the [refMap] instead.
     if (schema.recursiveRef != null) {
-      var nextSchema = schema.resolvePath(schema.recursiveRef);
-      if (nextSchema.recursiveAnchor == true) {
-        nextSchema = _findAnchorParent(nextSchema) ?? nextSchema;
-        _validate(nextSchema, instance);
-      } else {
-        final prevParent = _setDynamicParent(nextSchema, schema);
-        _validate(nextSchema, instance);
-        _setDynamicParent(nextSchema, prevParent);
-        if (schema.schemaVersion < SchemaVersion.draft2019_09) {
-          return;
+      _withRefScope(schema.recursiveRef, instance, () {
+        var nextSchema = schema.resolvePath(schema.recursiveRef);
+        if (nextSchema.recursiveAnchor == true) {
+          nextSchema = _findAnchorParent(nextSchema) ?? nextSchema;
+          _validate(nextSchema, instance);
+        } else {
+          final prevParent = _setDynamicParent(nextSchema, schema);
+          _validate(nextSchema, instance);
+          _setDynamicParent(nextSchema, prevParent);
         }
+      });
+      if (schema.schemaVersion < SchemaVersion.draft2019_09) {
+        return;
       }
     }
 

--- a/test/custom/valid_schemas/draft2019-09/example.json
+++ b/test/custom/valid_schemas/draft2019-09/example.json
@@ -18,5 +18,43 @@
         "valid": false
       }
     ]
+  },
+ {
+    "description": "Properties in refs are evaluated",
+    "schema": {
+      "$defs": {
+        "a": {
+          "multipleOf": 10,
+          "$ref": "#/$defs/b"
+        },
+        "b": {
+          "multipleOf": 3,
+          "$ref": "#/$defs/c"
+        },
+        "c": {
+          "type": "number"
+        }
+      },
+      "properties": {
+        "foo": {"$ref":  "#/$defs/a"}
+      }
+    },
+    "tests": [
+      {
+        "description": "30 passes",
+        "data": {"foo": 30},
+        "valid": true
+      },
+      {
+        "description": "20 is not a multiple of 3",
+        "data": {"foo":  20},
+        "valid": false
+      },
+      {
+        "description": "A String fails",
+        "data": {"foo": "String"},
+        "valid": false
+      }
+    ]
   }
 ]

--- a/test/unit/specification_tests.dart
+++ b/test/unit/specification_tests.dart
@@ -78721,6 +78721,44 @@ Map<String, String> specificationTests = {
         "valid": false
       }
     ]
+  },
+ {
+    "description": "Properties in refs are evaluated",
+    "schema": {
+      "$defs": {
+        "a": {
+          "multipleOf": 10,
+          "$ref": "#/$defs/b"
+        },
+        "b": {
+          "multipleOf": 3,
+          "$ref": "#/$defs/c"
+        },
+        "c": {
+          "type": "number"
+        }
+      },
+      "properties": {
+        "foo": {"$ref":  "#/$defs/a"}
+      }
+    },
+    "tests": [
+      {
+        "description": "30 passes",
+        "data": {"foo": 30},
+        "valid": true
+      },
+      {
+        "description": "20 is not a multiple of 3",
+        "data": {"foo":  20},
+        "valid": false
+      },
+      {
+        "description": "A String fails",
+        "data": {"foo": "String"},
+        "valid": false
+      }
+    ]
   }
 ]
 """


### PR DESCRIPTION
## Ultimate problem:
In draft 2019, properties along side refs aren't properly evaluated.


## How it was fixed:
Change the reference loop detection. Previously if the `JsonSchema` node that was just resolved contained a `$ref`, it was immediately resolved. Loop detection also happened with in this code.

In draft2019, we need to evaluate other properties in the returned ref. In draft 2019 and later we return immediately to allow other properties beside the ref can be evaluated. There is also a new loop-detector that takes into account the data being processed. This should be more robust with the dynamic scoping in draft 2019 and 2020.

The code path for draft7 and earlier should be unchanged for resolving nested refs.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf