### PR TITLE
Backport a hashing function from a newer dart.

### DIFF
--- a/lib/src/json_schema/utils.dart
+++ b/lib/src/json_schema/utils.dart
@@ -106,3 +106,26 @@ class DefaultValidators {
     }
   }
 }
+
+/// [Hasher] can be replaced with [Object.hash()] once the minimum language version is set to 2.14
+class Hasher {
+// These functions were yanked from Dart 2.14 hashing functions.
+  static int _combine(int hash, int value) {
+    hash = 0x1fffffff & (hash + value);
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int _finish(int hash) {
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+
+  static int hash2(int v1, int v2, [int seed = 0]) {
+    int hash = seed;
+    hash = _combine(hash, v1);
+    hash = _combine(hash, v2);
+    return _finish(hash);
+  }
+}

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -85,7 +85,27 @@ class _InstanceRefPair {
   bool operator ==(Object other) => other is _InstanceRefPair && this.path == other.path && this.ref == other.ref;
 
   @override
-  int get hashCode => Object.hash(this.path, this.ref);
+  int get hashCode => _hash2(this.path.hashCode, this.ref.hashCode);
+}
+
+// These functions were yanked from Dart 2.14 hashing functions.
+int _combine(int hash, int value) {
+  hash = 0x1fffffff & (hash + value);
+  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+  return hash ^ (hash >> 6);
+}
+
+int _finish(int hash) {
+  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+  hash = hash ^ (hash >> 11);
+  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+}
+// This can be replaced with Object.hash() once the minimum language version is set to 2.14
+int _hash2(int v1, int v2, [int seed = 0]) {
+  int hash = seed;
+  hash = _combine(hash, v1);
+  hash = _combine(hash, v2);
+  return _finish(hash);
 }
 
 /// The result of validating data against a schema

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -42,6 +42,7 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:json_schema/src/json_schema/typedefs.dart';
+import 'package:json_schema/src/json_schema/utils.dart';
 import 'package:logging/logging.dart';
 
 import 'package:json_schema/src/json_schema/constants.dart';
@@ -85,27 +86,8 @@ class _InstanceRefPair {
   bool operator ==(Object other) => other is _InstanceRefPair && this.path == other.path && this.ref == other.ref;
 
   @override
-  int get hashCode => _hash2(this.path.hashCode, this.ref.hashCode);
-}
-
-// These functions were yanked from Dart 2.14 hashing functions.
-int _combine(int hash, int value) {
-  hash = 0x1fffffff & (hash + value);
-  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-  return hash ^ (hash >> 6);
-}
-
-int _finish(int hash) {
-  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-  hash = hash ^ (hash >> 11);
-  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-}
-// This can be replaced with Object.hash() once the minimum language version is set to 2.14
-int _hash2(int v1, int v2, [int seed = 0]) {
-  int hash = seed;
-  hash = _combine(hash, v1);
-  hash = _combine(hash, v2);
-  return _finish(hash);
+  // This can be replaced with Object.hash() once the minimum language version is set to 2.14
+  int get hashCode => Hasher.hash2(this.path.hashCode, this.ref.hashCode);
 }
 
 /// The result of validating data against a schema


### PR DESCRIPTION
## Ultimate problem:
`Object.hash` doesn't exist in Dart 2.13

## How it was fixed:
Port the `Object.hash` implementation to this library to make this usable in earlier versions of dart.


## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf