### PR TITLE
Use Map.from() in JsonSchema._fromRootMap

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -65,7 +65,8 @@ class RetrievalRequest {
 /// the schema itself is done on construction. Any errors in the schema
 /// result in a FormatException being thrown.
 class JsonSchema {
-  JsonSchema._fromMap(this._root, this._schemaMap, this._path, {JsonSchema parent}) {
+  JsonSchema._fromMap(this._root, Map schemaMap, this._path, {JsonSchema parent}) {
+    this._schemaMap = schemaMap != null ? Map<String, dynamic>.from(schemaMap) : {};
     this._parent = parent;
     _initialize();
   }

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -66,7 +66,10 @@ class RetrievalRequest {
 /// result in a FormatException being thrown.
 class JsonSchema {
   JsonSchema._fromMap(this._root, Map schemaMap, this._path, {JsonSchema parent}) {
-    this._schemaMap = schemaMap != null ? Map<String, dynamic>.from(schemaMap) : {};
+    if (schemaMap == null) {
+      throw ArgumentError.notNull('schemaMap');
+    }
+    this._schemaMap = Map<String, dynamic>.from(schemaMap);
     this._parent = parent;
     _initialize();
   }
@@ -78,7 +81,10 @@ class JsonSchema {
 
   JsonSchema._fromRootMap(Map schemaMap, SchemaVersion schemaVersion,
       {Uri fetchedFromUri, bool isSync = false, Map<String, JsonSchema> refMap, RefProvider refProvider}) {
-    this._schemaMap = schemaMap != null ? Map<String, dynamic>.from(schemaMap) : {};
+    if (schemaMap == null) {
+      throw ArgumentError.notNull('schemaMap');
+    }
+    this._schemaMap = Map<String, dynamic>.from(schemaMap);
     _initialize(
       schemaVersion: schemaVersion,
       fetchedFromUri: fetchedFromUri,

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -75,8 +75,9 @@ class JsonSchema {
     _initialize();
   }
 
-  JsonSchema._fromRootMap(this._schemaMap, SchemaVersion schemaVersion,
+  JsonSchema._fromRootMap(Map schemaMap, SchemaVersion schemaVersion,
       {Uri fetchedFromUri, bool isSync = false, Map<String, JsonSchema> refMap, RefProvider refProvider}) {
+    this._schemaMap = schemaMap != null ? Map<String, dynamic>.from(schemaMap) : {};
     _initialize(
       schemaVersion: schemaVersion,
       fetchedFromUri: fetchedFromUri,

--- a/test/unit/json_schema/schema_create_test.dart
+++ b/test/unit/json_schema/schema_create_test.dart
@@ -27,6 +27,24 @@ void main() {
       expect(results.errors.length, 0);
     });
 
+    test('create with generic nested Map succeeds', () {
+      final schema = JsonSchema.create({
+        'properties': {
+          'multiple': {'multipleOf': 2},
+          'someKey': Map.from({
+            'properties': {
+              'multiple': {'multipleOf': 2},
+            }
+          }),
+        },
+      });
+      final results = schema.validateWithResults({
+        'multiple': 2,
+        'someKey': {'multiple': 2},
+      });
+      expect(results.errors.length, 0);
+    });
+
     test('create with typed Map succeeds', () {
       final schema = JsonSchema.create(LinkedHashMap<String, dynamic>.from({
         'properties': {

--- a/test/unit/json_schema/schema_create_test.dart
+++ b/test/unit/json_schema/schema_create_test.dart
@@ -54,5 +54,15 @@ void main() {
       final results = schema.validateWithResults({'multiple': 2});
       expect(results.errors.length, 0);
     });
+
+    test('create with Unmodifiable Map succeeds', () {
+      final schema = JsonSchema.create(Map.unmodifiable({
+        'properties': {
+          'multiple': {'multipleOf': 2}
+        }
+      }));
+      final results = schema.validateWithResults({'multiple': 2});
+      expect(results.errors.length, 0);
+    });
   });
 }

--- a/test/unit/json_schema/schema_create_test.dart
+++ b/test/unit/json_schema/schema_create_test.dart
@@ -1,0 +1,40 @@
+// This test suite verifies that creation of JsonSchema succeeds with valid inputs.
+
+import 'dart:collection';
+
+import 'package:json_schema/json_schema.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('create from maps', () {
+    test('create with Map literal succeeds', () {
+      final schema = JsonSchema.create({
+        'properties': {
+          'multiple': {'multipleOf': 2}
+        }
+      });
+      final results = schema.validateWithResults({'multiple': 2});
+      expect(results.errors.length, 0);
+    });
+
+    test('create with generic Map succeeds', () {
+      final schema = JsonSchema.create(Map.from({
+        'properties': {
+          'multiple': {'multipleOf': 2}
+        }
+      }));
+      final results = schema.validateWithResults({'multiple': 2});
+      expect(results.errors.length, 0);
+    });
+
+    test('create with typed Map succeeds', () {
+      final schema = JsonSchema.create(LinkedHashMap<String, dynamic>.from({
+        'properties': {
+          'multiple': {'multipleOf': 2}
+        }
+      }));
+      final results = schema.validateWithResults({'multiple': 2});
+      expect(results.errors.length, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Ultimate problem:

`JsonSchema._fromRootMap` is directly assigning to `_schemaMap`, which is typed as `Map<String, dynamic>`. `JsonSchema.create` and other constructors accept a `dynamic` input, and type check on `Map`. This allows for other types of Maps, e.g. `Map<dynamic, dynamic>`, that may contain acceptable data, but fail the type check.

## How it was fixed:

Use `Map<String, dynamic>.from()` to iterate over the input map and create the correctly typed map. This also will prevent accidental mutations to the input map.

## Testing suggestions:

Unit test coverage should be sufficient.

## Potential areas of regression:


---

> __FYA:__ @michaelcarter-wf