### PR TITLE
Make some changes so we can load baked in schemas from disk.

### DIFF
--- a/lib/src/json_schema/constants.dart
+++ b/lib/src/json_schema/constants.dart
@@ -155,7 +155,11 @@ class SchemaVersion implements Comparable<SchemaVersion> {
         return draft7;
       case 'https://json-schema.org/draft/2019-09/schema':
         return draft2019_09;
+      case 'https://json-schema.org/draft/2019-09/schema#':
+        return draft2019_09;
       case 'https://json-schema.org/draft/2020-12/schema':
+        return draft2020_12;
+      case 'https://json-schema.org/draft/2020-12/schema#':
         return draft2020_12;
       default:
         return null;
@@ -213,6 +217,10 @@ Map getStaticSchemaByURI(Uri ref) {
   if (ref.fragment != "") return null;
   final mapped = _staticSchemaMapping[standardizeUri(ref)];
   return mapped != null ? json.decode(mapped) : null;
+}
+
+Map getStaticSchemaByVersion(SchemaVersion version) {
+  return getStaticSchema(version.toString());
 }
 
 class JsonSchemaDefinitions {

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -342,7 +342,7 @@ class JsonSchema {
             localSchema = _refMap[baseUriString];
           } else if (baseUriString != null && SchemaVersion.fromString(baseUriString) != null) {
             // If the referenced URI is or within versioned schema spec.
-            final staticSchema = getStaticSchema(baseUriString);
+            final staticSchema = getStaticSchemaByVersion(SchemaVersion.fromString(baseUriString));
             if (staticSchema != null) {
               _addSchemaToRefMap(baseUriString, JsonSchema.create(staticSchema));
             }


### PR DESCRIPTION
## Ultimate problem:
With the 2019-09 and 2020-12 draft schemas, the library will miss loading the local version and attempt to load them from the network. 

## How it was fixed:
Add some additional checks to make sure the local schemas can be loaded.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf