### PR TITLE
Updated Pathing

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -603,6 +603,7 @@ class JsonSchema {
     JsonSchema firstResult;
     JsonSchema secondResult;
     dynamic firstError;
+    // ignore: unused_local_variable
     dynamic secondError;
     try {
       firstResult = _recursiveResolvePath(

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -613,14 +613,12 @@ class JsonSchema {
       Uri pathUri, ListSlice<String> fragments, JsonSchema baseSchema, Set<Uri> refsEncountered,
       {bool skipInitialRefCheck = false}) {
     if (fragments.isNotEmpty) {
+      var savedRefsEncountered = Set.of(refsEncountered);
       // Start at the baseSchema.
       JsonSchema currentSchema = baseSchema;
 
       // If currentSchema is a ref, we might want to resolve it recursively right now.
-      if (currentSchema.ref != null &&
-          currentSchema.ref != pathUri &&
-          !refsEncountered.contains(currentSchema.ref) &&
-          !skipInitialRefCheck) {
+      if (currentSchema.ref != null && !refsEncountered.contains(currentSchema.ref) && !skipInitialRefCheck) {
         // Set of properties that don't impact validation.
         final Set<String> consts = Set.of([r'$id', r'$schema', r'$comment']);
         Set<Uri> preRefsEncountered = Set.of(refsEncountered);
@@ -718,11 +716,6 @@ class JsonSchema {
           if (i + 1 == fragments.length && currentSchema._schemaMap.keys.toSet().difference(consts).length > 1) {
             continue;
           }
-          if (i + 1 < fragments.length &&
-              // currentSchema._schemaMap.keys.toSet().difference(consts).length > 1 &&
-              refsEncountered.contains(currentSchema.ref)) {
-            continue;
-          }
           Set<Uri> preRefsEncountered = Set.of(refsEncountered);
           if (!refsEncountered.add(currentSchema.ref)) {
             // Throw if cycle is detected for currentSchema ref.
@@ -743,6 +736,21 @@ class JsonSchema {
           currentSchema = nextSchema;
         }
       }
+      // if (baseSchema.ref != null) {
+      //   JsonSchema foo;
+      //   try {
+      //     foo = baseSchema._getSchemaFromPath(baseSchema.ref, savedRefsEncountered);
+      //   } catch (e) {
+      //     return currentSchema;
+      //   }
+      //
+      //   if (foo != null) {
+      //     var res = _recursiveResolvePath(pathUri, fragments, foo, savedRefsEncountered);
+      //     if (res != null) {
+      //       throw Exception("sucks");
+      //     }
+      //   }
+      // }
 
       // Return the successfully resolved schema from fragment path.
       return currentSchema;

--- a/test/unit/json_schema/resolve_path_test.dart
+++ b/test/unit/json_schema/resolve_path_test.dart
@@ -2,13 +2,17 @@ import 'package:json_schema/json_schema.dart';
 import 'package:test/test.dart';
 
 main() {
-  JsonSchema fooSchema;
+  JsonSchema testSchema;
   setUp(() async {
-    fooSchema = await JsonSchema.createAsync({
+    testSchema = await JsonSchema.createAsync({
+      '\$id': 'root',
       '\$defs': {
         'a': {
+          '\$anchor': 'a_anchor',
           'const': 'found in ref',
-          'deeper': {'const': 'deeper in the schema'},
+          'properties': {
+            'deeper': {'const': 'deeper in the schema'},
+          },
           '\$ref': '#/\$defs/b'
         },
         'b': {'const': 'b in not resolved'}
@@ -16,7 +20,7 @@ main() {
       'properties': {
         'foo': {'\$ref': '#/\$defs/a'},
         'baz': {
-          '\$ref': '#/\$defs/a',
+          '\$ref': '#a_anchor',
           'findMe': {'const': 'is found'}
         }
       }
@@ -24,19 +28,41 @@ main() {
   });
   group('Resolve path', () {
     test('ref resolved immediately when it is the only property.', () {
-      var ref = fooSchema.resolvePath(Uri.parse('#/properties/foo'));
+      var ref = testSchema.resolvePath(Uri.parse('#/properties/foo'));
       expect(ref.constValue, 'found in ref');
     });
 
     test('ref should not resolve when there are multiple properties', () {
-      var ref = fooSchema.resolvePath(Uri.parse('#/properties/baz'));
+      var ref = testSchema.resolvePath(Uri.parse('#/properties/baz'));
       expect(ref.constValue, null);
       expect(ref.ref == null, false);
     });
 
     test('should continue resolving in the current node even if there is a ref', () {
-      final schema = fooSchema.resolvePath(Uri.parse('#/properties/baz/findMe'));
-      expect(schema.constValue, 'is found');
+      final ref = testSchema.resolvePath(Uri.parse('#/properties/baz/findMe'));
+      expect(ref.constValue, 'is found');
+    });
+
+    test('should follow the ref and continue resolving', () {
+      final ref = testSchema.resolvePath(Uri.parse('#/properties/baz/properties/deeper'));
+      expect(ref.constValue, 'deeper in the schema');
+    });
+
+    test('should throw an exception when there in an ambiguous path', () async {
+      final testSchema = await JsonSchema.createAsync({
+        "\$ref": "#/\$defs/objectX",
+        "properties": {
+          "a": {"minimum": 1, "maximum": 2}
+        },
+        "\$defs": {
+          "objectX": {
+            "properties": {
+              "a": {"type": "string"}
+            }
+          }
+        }
+      }, schemaVersion: SchemaVersion.draft2020_12);
+      expect(() => testSchema.resolvePath(Uri.parse('#/properties/a')), throwsException);
     });
   });
 }

--- a/test/unit/json_schema/schema_create_test.dart
+++ b/test/unit/json_schema/schema_create_test.dart
@@ -13,7 +13,7 @@ void main() {
           'multiple': {'multipleOf': 2}
         }
       });
-      final results = schema.validateWithResults({'multiple': 2});
+      final results = schema.validate({'multiple': 2});
       expect(results.errors.length, 0);
     });
 
@@ -23,7 +23,7 @@ void main() {
           'multiple': {'multipleOf': 2}
         }
       }));
-      final results = schema.validateWithResults({'multiple': 2});
+      final results = schema.validate({'multiple': 2});
       expect(results.errors.length, 0);
     });
 
@@ -38,7 +38,7 @@ void main() {
           }),
         },
       });
-      final results = schema.validateWithResults({
+      final results = schema.validate({
         'multiple': 2,
         'someKey': {'multiple': 2},
       });
@@ -51,7 +51,7 @@ void main() {
           'multiple': {'multipleOf': 2}
         }
       }));
-      final results = schema.validateWithResults({'multiple': 2});
+      final results = schema.validate({'multiple': 2});
       expect(results.errors.length, 0);
     });
 
@@ -61,7 +61,7 @@ void main() {
           'multiple': {'multipleOf': 2}
         }
       }));
-      final results = schema.validateWithResults({'multiple': 2});
+      final results = schema.validate({'multiple': 2});
       expect(results.errors.length, 0);
     });
   });

--- a/test/unit/json_schema/specification_test.dart
+++ b/test/unit/json_schema/specification_test.dart
@@ -36,6 +36,7 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
+@TestOn('vm')
 import 'dart:convert';
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/validator.dart';
@@ -145,43 +146,43 @@ void main() {
   });
 
   //Run all tests asynchronously with no ref provider.
-  runAllTestsForDraftX(
-    SchemaVersion.draft4,
-    allDraft4,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft6,
-    allDraft6,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft7,
-    allDraft7,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft2019_09,
-    allDraft2019,
-    draft2019SkippedTestFiles,
-    commonSkippedTests,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft2019_09,
-    draft2019Format,
-    draft2019FormatSkippedTestFiles,
-    commonSkippedTests,
-    validateFormats: true,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft2020_12,
-    allDraft2020,
-    draft2020SkippedTestFiles,
-    commonSkippedTests,
-  );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft4,
+  //   allDraft4,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft6,
+  //   allDraft6,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft7,
+  //   allDraft7,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2019_09,
+  //   allDraft2019,
+  //   draft2019SkippedTestFiles,
+  //   commonSkippedTests,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2019_09,
+  //   draft2019Format,
+  //   draft2019FormatSkippedTestFiles,
+  //   commonSkippedTests,
+  //   validateFormats: true,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2020_12,
+  //   allDraft2020,
+  //   draft2020SkippedTestFiles,
+  //   commonSkippedTests,
+  // );
 
   // Run all tests synchronously with a sync json provider.
   runAllTestsForDraftX(
@@ -243,55 +244,55 @@ void main() {
   );
 
   // Run all tests asynchronously with an async json provider.
-  runAllTestsForDraftX(
-    SchemaVersion.draft4,
-    allDraft4,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft6,
-    allDraft6,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft7,
-    allDraft6,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft7,
-    allDraft7,
-    commonSkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft2019_09,
-    allDraft2019,
-    draft2019SkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
-  runAllTestsForDraftX(
-    SchemaVersion.draft2019_09,
-    draft2019Format,
-    draft2019FormatSkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-    validateFormats: true,
-  );
-
-  runAllTestsForDraftX(
-    SchemaVersion.draft2020_12,
-    allDraft2020,
-    draft2020SkippedTestFiles,
-    commonSkippedTests,
-    refProvider: asyncRefProvider,
-  );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft4,
+  //   allDraft4,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft6,
+  //   allDraft6,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft7,
+  //   allDraft6,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft7,
+  //   allDraft7,
+  //   commonSkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2019_09,
+  //   allDraft2019,
+  //   draft2019SkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2019_09,
+  //   draft2019Format,
+  //   draft2019FormatSkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  //   validateFormats: true,
+  // );
+  //
+  // runAllTestsForDraftX(
+  //   SchemaVersion.draft2020_12,
+  //   allDraft2020,
+  //   draft2020SkippedTestFiles,
+  //   commonSkippedTests,
+  //   refProvider: asyncRefProvider,
+  // );
 }

--- a/test/unit/json_schema/specification_test.dart
+++ b/test/unit/json_schema/specification_test.dart
@@ -36,7 +36,6 @@
 //     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //     THE SOFTWARE.
 
-@TestOn('vm')
 import 'dart:convert';
 import 'package:json_schema/json_schema.dart';
 import 'package:json_schema/src/json_schema/validator.dart';
@@ -146,43 +145,43 @@ void main() {
   });
 
   //Run all tests asynchronously with no ref provider.
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft4,
-  //   allDraft4,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft6,
-  //   allDraft6,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft7,
-  //   allDraft7,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2019_09,
-  //   allDraft2019,
-  //   draft2019SkippedTestFiles,
-  //   commonSkippedTests,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2019_09,
-  //   draft2019Format,
-  //   draft2019FormatSkippedTestFiles,
-  //   commonSkippedTests,
-  //   validateFormats: true,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2020_12,
-  //   allDraft2020,
-  //   draft2020SkippedTestFiles,
-  //   commonSkippedTests,
-  // );
+  runAllTestsForDraftX(
+    SchemaVersion.draft4,
+    allDraft4,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft6,
+    allDraft6,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft7,
+    allDraft7,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    allDraft2019,
+    draft2019SkippedTestFiles,
+    commonSkippedTests,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    validateFormats: true,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2020_12,
+    allDraft2020,
+    draft2020SkippedTestFiles,
+    commonSkippedTests,
+  );
 
   // Run all tests synchronously with a sync json provider.
   runAllTestsForDraftX(
@@ -244,55 +243,55 @@ void main() {
   );
 
   // Run all tests asynchronously with an async json provider.
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft4,
-  //   allDraft4,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft6,
-  //   allDraft6,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft7,
-  //   allDraft6,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft7,
-  //   allDraft7,
-  //   commonSkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2019_09,
-  //   allDraft2019,
-  //   draft2019SkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2019_09,
-  //   draft2019Format,
-  //   draft2019FormatSkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  //   validateFormats: true,
-  // );
-  //
-  // runAllTestsForDraftX(
-  //   SchemaVersion.draft2020_12,
-  //   allDraft2020,
-  //   draft2020SkippedTestFiles,
-  //   commonSkippedTests,
-  //   refProvider: asyncRefProvider,
-  // );
+  runAllTestsForDraftX(
+    SchemaVersion.draft4,
+    allDraft4,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft6,
+    allDraft6,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft7,
+    allDraft6,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft7,
+    allDraft7,
+    commonSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    allDraft2019,
+    draft2019SkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
+  runAllTestsForDraftX(
+    SchemaVersion.draft2019_09,
+    draft2019Format,
+    draft2019FormatSkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+    validateFormats: true,
+  );
+
+  runAllTestsForDraftX(
+    SchemaVersion.draft2020_12,
+    allDraft2020,
+    draft2020SkippedTestFiles,
+    commonSkippedTests,
+    refProvider: asyncRefProvider,
+  );
 }


### PR DESCRIPTION
## Ultimate problem:

The `resolvePath` method skips over a `$ref` in the root of a JsonSchema object. It also throws an exception as soon as there is a JsonSchema object with a matching fragment and a `$ref`. Previous attempts to improve this behavior would cause certain schemas to throw cycle errors when none were present.

## How it was fixed:
When there are still fragments to traverse, look down both paths. A path will either resolve or return an error. Memomize the results of path looks ups. Once a path has been looked up, no need to look it up agan.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf