### PR TITLE
RM-135877 Release json_schema 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.0.1
+- Performance:
+  - cache calls to `resolvePath`
+  - `JsonSchema.schemaMap` is now truly unmodifiable (was before in practice anyway) and `hashCode` is cached by taking advantage of that.
+- 4.0 Release Mistake:
+  - `Validator.evaluatedProperties` was accidentally made public, pull it back to private.
+
 ## 4.0.0
 
 json_schema 4.0 continues our journey to support additional new versions of the JSON Schema specification (Draft 2019-09 and Draft 2020-12)! Custom vocabulary and format support is also included in this release! In addition to those major features, we have better support for certain built-in formats, as well as improved spec test compliance. 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 4.0.0
+version: 4.0.1
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [imp(json-schema): memoize hashCode and make schemaMap immutable](https://github.com/Workiva/json_schema/pull/139)


Requested by: @michaelcarter-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/4.0.0...Workiva:release_json_schema_4.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/4.0.0...4.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?pull_number=140&repo_name=Workiva%2Fjson_schema)