### PR TITLE
RM-136241 Release json_schema 4.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 4.0.1
+version: 4.0.2
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [TASKPLAT-1105: support null typeList in type getter](https://github.com/Workiva/json_schema/pull/141)


Requested by: @michaelcarter-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/4.0.1...Workiva:release_json_schema_4.0.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/4.0.1...4.0.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?pull_number=142&repo_name=Workiva%2Fjson_schema)