### PR TITLE
CPLAT-17467 Remove usages of .slice to work around a dart2js compiler bug

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -346,7 +346,9 @@ class JsonSchema {
     } else if (_root.schemaVersion == SchemaVersion.draft6) {
       accessMap = _accessMapV6;
     } else if (_root.schemaVersion >= SchemaVersion.draft2019_09) {
-      final vocabMap = Map()..addAll(_vocabMaps)..addAll(_customVocabMap);
+      final vocabMap = Map()
+        ..addAll(_vocabMaps)
+        ..addAll(_customVocabMap);
       this.metaschemaVocabulary.keys.forEach((vocabUri) {
         accessMap.addAll(vocabMap[vocabUri.toString()]);
       });

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -595,7 +595,7 @@ class JsonSchema {
     // Follow JSON Pointer path of fragments if provided.
     if (pathUri.fragment.isNotEmpty) {
       final List<String> fragments = Uri.parse(pathUri.fragment).pathSegments;
-      final foundSchema = _recursiveResolvePath(pathUri, fragments.slice(0), baseSchema, refsEncountered);
+      final foundSchema = _recursiveResolvePath(pathUri, fragments, baseSchema, refsEncountered);
       _memomizedResults[currentPair] = foundSchema;
       return foundSchema;
     }
@@ -607,7 +607,7 @@ class JsonSchema {
   // When there are 2 possible path to be resolve, traverse both paths.
   JsonSchema _resolveParallelPaths(
     Uri pathUri, // The path being resolved
-    ListSlice<String> fragments, // A slice of fragments being traversed.
+    List<String> fragments, // A slice of fragments being traversed.
     JsonSchema schemaWithRef, // A JsonSchema containing a ref.
     Set<Uri> refsEncountered, // Refs encountered from schemaWithRef
   ) {
@@ -667,7 +667,7 @@ class JsonSchema {
   }
 
   JsonSchema _recursiveResolvePath(
-      Uri pathUri, ListSlice<String> fragments, JsonSchema baseSchema, Set<Uri> refsEncountered,
+      Uri pathUri, List<String> fragments, JsonSchema baseSchema, Set<Uri> refsEncountered,
       {bool skipInitialRefCheck = false}) {
     // Set of properties that are ignored when set beside a `$ref`.
     final Set<String> consts = Set.of([r'$id', r'$schema', r'$comment']);
@@ -762,7 +762,7 @@ class JsonSchema {
           // If currentSchema has additional values, then traverse both paths to find the result.
           if (i + 1 < fragments.length && currentSchema._schemaMap.keys.toSet().difference(consts).length > 1) {
             return _resolveParallelPaths(
-                pathUri, fragments.slice(i, fragments.length - 1), currentSchema, refsEncountered);
+                pathUri, fragments.sublist(i, fragments.length - 1), currentSchema, refsEncountered);
           }
 
           currentSchema = _resolveSchemaWithAccounting(pathUri, currentSchema, refsEncountered);

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -607,7 +607,7 @@ class JsonSchema {
   // When there are 2 possible path to be resolve, traverse both paths.
   JsonSchema _resolveParallelPaths(
     Uri pathUri, // The path being resolved
-    List<String> fragments, // A slice of fragments being traversed.
+    List<String> fragments, // A list of fragments being traversed.
     JsonSchema schemaWithRef, // A JsonSchema containing a ref.
     Set<Uri> refsEncountered, // Refs encountered from schemaWithRef
   ) {

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -346,9 +346,7 @@ class JsonSchema {
     } else if (_root.schemaVersion == SchemaVersion.draft6) {
       accessMap = _accessMapV6;
     } else if (_root.schemaVersion >= SchemaVersion.draft2019_09) {
-      final vocabMap = Map()
-        ..addAll(_vocabMaps)
-        ..addAll(_customVocabMap);
+      final vocabMap = Map()..addAll(_vocabMaps)..addAll(_customVocabMap);
       this.metaschemaVocabulary.keys.forEach((vocabUri) {
         accessMap.addAll(vocabMap[vocabUri.toString()]);
       });
@@ -595,7 +593,7 @@ class JsonSchema {
     // Follow JSON Pointer path of fragments if provided.
     if (pathUri.fragment.isNotEmpty) {
       final List<String> fragments = Uri.parse(pathUri.fragment).pathSegments;
-      final foundSchema = _recursiveResolvePath(pathUri, fragments, baseSchema, refsEncountered);
+      final foundSchema = _recursiveResolvePath(pathUri, fragments.sublist(0), baseSchema, refsEncountered);
       _memomizedResults[currentPair] = foundSchema;
       return foundSchema;
     }
@@ -761,7 +759,7 @@ class JsonSchema {
           // If currentSchema has additional values, then traverse both paths to find the result.
           if (i + 1 < fragments.length && currentSchema._schemaMap.keys.toSet().difference(consts).length > 1) {
             return _resolveParallelPaths(
-                pathUri, fragments.sublist(i, fragments.length - 1), currentSchema, refsEncountered);
+                pathUri, fragments.sublist(i + 1, fragments.length), currentSchema, refsEncountered);
           }
 
           currentSchema = _resolveSchemaWithAccounting(pathUri, currentSchema, refsEncountered);

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -666,8 +666,7 @@ class JsonSchema {
     return null;
   }
 
-  JsonSchema _recursiveResolvePath(
-      Uri pathUri, List<String> fragments, JsonSchema baseSchema, Set<Uri> refsEncountered,
+  JsonSchema _recursiveResolvePath(Uri pathUri, List<String> fragments, JsonSchema baseSchema, Set<Uri> refsEncountered,
       {bool skipInitialRefCheck = false}) {
     // Set of properties that are ignored when set beside a `$ref`.
     final Set<String> consts = Set.of([r'$id', r'$schema', r'$comment']);

--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -593,7 +593,7 @@ class JsonSchema {
     // Follow JSON Pointer path of fragments if provided.
     if (pathUri.fragment.isNotEmpty) {
       final List<String> fragments = Uri.parse(pathUri.fragment).pathSegments;
-      final foundSchema = _recursiveResolvePath(pathUri, fragments.sublist(0), baseSchema, refsEncountered);
+      final foundSchema = _recursiveResolvePath(pathUri, fragments, baseSchema, refsEncountered);
       _memomizedResults[currentPair] = foundSchema;
       return foundSchema;
     }


### PR DESCRIPTION
## Ultimate problem:
For some reason, code using ListSlice sometimes triggers the following dart2js compiler bug: https://github.com/dart-lang/sdk/issues/48762

<details>
<summary>The error it produces (click to expand)</summary>

```
org-dartlang-app:///packages/collection/src/algorithms.dart@14383+1:
Internal Error: Runtime type information not available for type_variable_local(j:type_variable(quickSort.E)) in (SyntheticLocal(result), local(quickSort#elements), local(quickSort#compare), local(quickSort#start), local(quickSort#end)) for j:method(quickSort).
The compiler is broken.

When compiling the above element, the compiler crashed. It is not
possible to tell if this is caused by a problem in your program or
not. Regardless, the compiler should not crash.

The Dart team would greatly appreciate if you would take a moment to
report this problem at http://dartbug.com/new.

Please include the following information:

* the name and version of your operating system,

* the Dart SDK build number (2.13.4), and

* the entire message you see here (including the full stack trace
  below as well as the source location above).


StdErr:
Unhandled exception:
Assertion failure: Runtime type information not available for type_variable_local(j:type_variable(quickSort.E)) in (SyntheticLocal(result), local(quickSort#elements), local(quickSort#compare), local(quickSort#start), local(quickSort#end)) for j:method(quickSort).
#0      failedAt (package:compiler/src/diagnostics/invariant.dart:49:3)
#1      LocalsHandler.readLocal (package:compiler/src/ssa/locals_handler.dart:354:11)
#2      TypeBuilder._buildEnvironmentForType (package:compiler/src/ssa/type_builder.dart:289:12)
#3      TypeBuilder.analyzeTypeArgumentNewRti (package:compiler/src/ssa/type_builder.dart:207:9)
#4      TypeBuilder.analyzeTypeArgument (package:compiler/src/ssa/type_builder.dart:191:12)
#5      KernelSsaGraphBuilder.visitInstantiation (package:compiler/src/ssa/builder_kernel.dart:5212:24)
#6      Instantiation.accept (package:kernel/ast.dart:6291:44)
#7      KernelSsaGraphBuilder._visitPositionalArguments (package:compiler/src/ssa/builder_kernel.dart:3616:16)
#8      KernelSsaGraphBuilder._visitArgumentsForStaticTarget (package:compiler/src/ssa/builder_kernel.dart:3736:33)
#9      KernelSsaGraphBuilder.visitStaticInvocation (package:compiler/src/ssa/builder_kernel.dart:3820:11)
#10     StaticInvocation.accept (package:kernel/ast.dart:6120:44)
#11     KernelSsaGraphBuilder.visitExpressionStatement (package:compiler/src/ssa/builder_kernel.dart:1765:18)
#12     ExpressionStatement.accept (package:kernel/ast.dart:8462:43)
#13     KernelSsaGraphBuilder.visitBlock (package:compiler/src/ssa/builder_kernel.dart:1731:17)
#14     Block.accept (package:kernel/ast.dart:8518:43)
#15     KernelSsaGraphBuilder._visitInlinedFunction (package:compiler/src/ssa/builder_kernel.dart:6325:30)
#16     KernelSsaGraphBuilder._doInline (package:compiler/src/ssa/builder_kernel.dart:6303:5)
#17     KernelSsaGraphBuilder._tryInlineMethod.doInlining.<anonymous closure> (package:compiler/src/ssa/builder_kernel.dart:5984:11)
#18     KernelSsaGraphBuilder._inlinedFrom.<anonymous closure> (package:compiler/src/ssa/builder_kernel.dart:926:21)
#19     CompilerDiagnosticReporter.withCurrentElement (package:compiler/src/compiler.dart:819:15)
#20     KernelSsaGraphBuilder._inlinedFrom (package:compiler/src/ssa/builder_kernel.dart:924:14)
#21     KernelSsaGraphBuilder._tryInlineMethod.doInlining (package:compiler/src/ssa/builder_kernel.dart:5979:7)
#22     KernelSsaGraphBuilder._tryInlineMethod (package:compiler/src/ssa/builder_kernel.dart:5991:17)
#23     KernelSsaGraphBuilder._pushStaticInvocation (package:compiler/src/ssa/builder_kernel.dart:4939:9)
#24     KernelSsaGraphBuilder.visitStaticInvocation (package:compiler/src/ssa/builder_kernel.dart:3841:5)
#25     StaticInvocation.accept (package:kernel/ast.dart:6120:44)
#26     KernelSsaGraphBuilder.visitExpressionStatement (package:compiler/src/ssa/builder_kernel.dart:1765:18)
#27     ExpressionStatement.accept (package:kernel/ast.dart:8462:43)
#28     KernelSsaGraphBuilder.visitBlock (package:compiler/src/ssa/builder_kernel.dart:1731:17)
#29     Block.accept (package:kernel/ast.dart:8518:43)
#30     KernelSsaGraphBuilder._buildFunctionNode (package:compiler/src/ssa/builder_kernel.dart:1260:23)
#31     KernelSsaGraphBuilder.build.<anonymous closure> (package:compiler/src/ssa/builder_kernel.dart:444:15)
#32     CompilerDiagnosticReporter.withCurrentElement (package:compiler/src/compiler.dart:819:15)
#33     KernelSsaGraphBuilder.build (package:compiler/src/ssa/builder_kernel.dart:429:21)
#34     KernelSsaBuilder.build.<anonymous closure> (package:compiler/src/js_model/js_strategy.dart:502:22)
#35     CompilerTask.measure (package:compiler/src/common/tasks.dart:66:51)
#36     KernelSsaBuilder.build (package:compiler/src/js_model/js_strategy.dart:485:18)
#37     SsaBuilderTask.build (package:compiler/src/ssa/ssa.dart:346:21)
#38     SsaFunctionCompiler.compile (package:compiler/src/ssa/ssa.dart:80:29)
#39     OnDemandCodegenResults.getCodegenResults (package:compiler/src/common/codegen.dart:454:30)
#40     JsBackendStrategy.generateCode (package:compiler/src/js_model/js_strategy.dart:318:43)
#41     KernelCodegenWorkItem.run (package:compiler/src/js_model/js_strategy.dart:452:29)
#42     Compiler.emptyQueue.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:compiler/src/compiler.dart:530:70)
#43     CompilerTask.measureSubtask (package:compiler/src/common/tasks.dart:181:35)
#44     Compiler.emptyQueue.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:compiler/src/compiler.dart:530:32)
#45     CompilerTask.measureSubtask (package:compiler/src/common/tasks.dart:181:35)
#46     Compiler.emptyQueue.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:compiler/src/compiler.dart:528:28)
#47     CompilerDiagnosticReporter.withCurrentElement (package:compiler/src/compiler.dart:819:15)
#48     Compiler.emptyQueue.<anonymous closure>.<anonymous closure> (package:compiler/src/compiler.dart:526:18)
#49     CodegenEnqueuer._forEach (package:compiler/src/js_backend/enqueuer.dart:269:12)
#50     CodegenEnqueuer.forEach (package:compiler/src/js_backend/enqueuer.dart:285:5)
#51     Compiler.emptyQueue.<anonymous closure> (package:compiler/src/compiler.dart:522:16)
#52     CompilerTask.measureSubtask (package:compiler/src/common/tasks.dart:181:35)
#53     Compiler.emptyQueue (package:compiler/src/compiler.dart:521:14)
#54     Compiler.processQueue.<anonymous closure> (package:compiler/src/compiler.dart:547:7)
#55     CompilerTask.measureSubtask (package:compiler/src/common/tasks.dart:181:35)
#56     Compiler.processQueue (package:compiler/src/compiler.dart:540:14)
#57     Compiler.runCodegenEnqueuer (package:compiler/src/compiler.dart:428:5)
#58     Compiler.generateJavaScriptCode (package:compiler/src/compiler.dart:331:9)
#59     Compiler.compileFromKernel.<anonymous closure> (package:compiler/src/compiler.dart:503:7)
#60     CompilerTask.measureSubtask (package:compiler/src/common/tasks.dart:181:35)
#61     Compiler.compileFromKernel (package:compiler/src/compiler.dart:469:14)
#62     Compiler.runInternal (package:compiler/src/compiler.dart:304:13)
<asynchronous suspension>
```

</details>

## How it was fixed:
Remove code using ListSlice (replace `.slice` with `.sublist`, which seems to work around the issue in at least some cases.

This seemed safe to do, since the slices weren't being mutated, and only read from.

## Testing suggestions:
CI passes (assuming there's good test coverage around this method)

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf