### PR TITLE
remove dart 3 from CI for now

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ stable ]
+        sdk: [ 2.18.7, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.18.7, stable ]
+        sdk: [ stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ stable, beta, dev ]
+        sdk: [ 2.18.7, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,15 +8,15 @@ environment:
 
 dependencies:
   collection: ^1.14.6
-  http: ">=0.12.0 <0.14.0"
+  http: ^0.13.0
   logging: ^1.0.0
   rfc_6901: ^0.1.0
   uri: '>=0.11.1 <2.0.0'
 
 dev_dependencies:
   dependency_validator: ^3.1.2
-  path: ^1.3.0
-  shelf: ^0.7.9
-  shelf_static: ^0.2.9
-  test: ^1.9.1
+  path: ^1.8.0
+  shelf: ^1.0.0
+  shelf_static: ^1.0.0
+  test: ^1.17.0
   workiva_analysis_options: ^1.2.2


### PR DESCRIPTION
## Ultimate problem:

This package isn't nullsafe yet so the dev and beta channels in the CI matrix are failing.

## How it was fixed:

Remove those stages until we've updated to null safety. 
Also updates a few dependencies so that it resolves to a new enough test package that doesn't try to use the removed to level dart2js command line.

CI should pass without any failures now.

