### PR TITLE
Minor cleanup

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,5 @@
+test
+tool
+Makefile
+Dockerfile
+dart_test.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.1
+- Clean up pubspec, add .pubignore
 ## 5.0.0
 - Bump minimum Dart SDK version to 2.12.0
 - Migration to null safety

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  collection: ^1.15.0-nullsafety.4
-  http: "^0.13.4"
-  logging: '>=0.9.3 <2.0.0'
+  collection: ^1.15.0
+  http: ^0.13.4
+  logging: ^1.0.0
   rfc_6901: ^0.1.0
   uri: '>=0.11.1 <2.0.0'
 


### PR DESCRIPTION
## Summary

Perform some minor cleanup after the null migration
- remove the pre-release version of collection
- update logging dependency to ^1.0.0
- add a .pubignore to only publish relevant files