### PR TITLE
Update http dependency to version 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: ^0.13.4
+  http: ^1.0.0
   logging: ^1.0.0
   rfc_6901: ^0.1.0
   uri: '>=0.11.1 <2.0.0'


### PR DESCRIPTION
## Ultimate problem:

I noticed that there is a new version of the `http` package available. The version used here has not been updated yet.

## How it was fixed:

The dependency was updated.

## Testing suggestions:

CI should pass.

## Potential areas of regression:

Every area where the `http` package is being used. Regression is possible since it is a new major version.

---

> __FYA:__ @michaelcarter-wf