### PR TITLE
feat(package): add empty constructor for convenience

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -68,6 +68,8 @@ class RetrievalRequest {
   SyncRetrievalOperation syncRetrievalOperation;
 }
 
+final Map<SchemaVersion, JsonSchema> _emptySchemas = {};
+
 /// Constructed with a json schema, either as string or Map. Validation of
 /// the schema itself is done on construction. Any errors in the schema
 /// result in a FormatException being thrown.
@@ -268,6 +270,11 @@ class JsonSchema {
   }) {
     return createClient()?.createFromUrl(schemaUrl,
         schemaVersion: schemaVersion, customVocabularies: customVocabularies, customFormats: customFormats);
+  }
+
+  /// Create an empty schema.
+  static JsonSchema empty({SchemaVersion schemaVersion = SchemaVersion.defaultVersion}) {
+    return _emptySchemas[schemaVersion] ??= JsonSchema.create({}, schemaVersion: schemaVersion);
   }
 
   /// Construct and validate a JsonSchema.
@@ -1509,7 +1516,7 @@ class JsonSchema {
   ///
   /// Note: Only one version can be used for a nested [JsonSchema] object.
   /// Default: [SchemaVersion.draft7]
-  SchemaVersion get schemaVersion => _root._schemaVersion ?? SchemaVersion.draft7;
+  SchemaVersion get schemaVersion => _root._schemaVersion ?? SchemaVersion.defaultVersion;
 
   /// Base [Uri] of the [JsonSchema] based on $id, or where it was fetched from, in that order, if any.
   Uri get _uriBase => _idBase ?? _fetchedFromUriBase;
@@ -2330,7 +2337,7 @@ class JsonSchema {
     } else if (schema is Map && schema[r'$schema'] is String) {
       return TypeValidators.builtInSchemaVersion(r'$schema', schema[r'$schema']);
     }
-    return SchemaVersion.draft7;
+    return SchemaVersion.defaultVersion;
   }
 
   /// Validate, calculate and set the value of the 'title' JSON Schema keyword.

--- a/lib/src/json_schema/models/schema_version.dart
+++ b/lib/src/json_schema/models/schema_version.dart
@@ -49,6 +49,8 @@ class SchemaVersion implements Comparable<SchemaVersion> {
 
   static const SchemaVersion draft2020_12 = SchemaVersion._(4);
 
+  static const SchemaVersion defaultVersion = SchemaVersion.draft7;
+
   static List<SchemaVersion> get values => const <SchemaVersion>[draft4, draft6, draft7, draft2019_09, draft2020_12];
 
   final int value;

--- a/test/unit/json_schema/empty_schemas.dart
+++ b/test/unit/json_schema/empty_schemas.dart
@@ -1,0 +1,20 @@
+import 'package:json_schema/json_schema.dart';
+import 'package:test/test.dart';
+
+main() {
+  test('can get an empty schema for any version', () {
+    for (final version in SchemaVersion.values) {
+      final emptySchema = JsonSchema.empty(schemaVersion: version);
+      expect(emptySchema.schemaVersion, equals(version));
+    }
+  });
+  test('defaults to the current default version', () {
+    final emptySchema = JsonSchema.empty();
+    expect(emptySchema.schemaVersion, equals(SchemaVersion.defaultVersion));
+  });
+  test('calling JsonSchema.empty on the same version has same identity', () {
+    final thing1 = JsonSchema.empty();
+    final thing2 = JsonSchema.empty();
+    expect(identical(thing1, thing2), isTrue);
+  });
+}

--- a/test/unit/json_schema/empty_schemas.dart
+++ b/test/unit/json_schema/empty_schemas.dart
@@ -2,19 +2,21 @@ import 'package:json_schema/json_schema.dart';
 import 'package:test/test.dart';
 
 main() {
-  test('can get an empty schema for any version', () {
-    for (final version in SchemaVersion.values) {
-      final emptySchema = JsonSchema.empty(schemaVersion: version);
-      expect(emptySchema.schemaVersion, equals(version));
-    }
-  });
-  test('defaults to the current default version', () {
-    final emptySchema = JsonSchema.empty();
-    expect(emptySchema.schemaVersion, equals(SchemaVersion.defaultVersion));
-  });
-  test('calling JsonSchema.empty on the same version has same identity', () {
-    final thing1 = JsonSchema.empty();
-    final thing2 = JsonSchema.empty();
-    expect(identical(thing1, thing2), isTrue);
+  group('JsonSchema.empty', () {
+    test('can get an empty schema for any version', () {
+      for (final version in SchemaVersion.values) {
+        final emptySchema = JsonSchema.empty(schemaVersion: version);
+        expect(emptySchema.schemaVersion, equals(version));
+      }
+    });
+    test('defaults to the current default version', () {
+      final emptySchema = JsonSchema.empty();
+      expect(emptySchema.schemaVersion, equals(SchemaVersion.defaultVersion));
+    });
+    test('calling JsonSchema.empty on the same version has same identity', () {
+      final thing1 = JsonSchema.empty();
+      final thing2 = JsonSchema.empty();
+      expect(identical(thing1, thing2), isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Ultimate problem:
- Lots of people use empty schemas as a default somewhere

## How it was fixed:
- Make it easier and also fast

## Testing suggestions:


## Potential areas of regression:



---
