### PR TITLE
feat(package): support relative refs in resolvePath

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -1455,8 +1455,10 @@ class JsonSchema {
     return accessorMap;
   }
 
+  // temporarily uses a constructed full path for relative. can be optimized in the future
   /// Get a nested [JsonSchema] from a path.
-  JsonSchema resolvePath(Uri? path) => _getSchemaFromPath(path);
+  JsonSchema resolvePath(Uri? path) =>
+      _getSchemaFromPath(path?.toString().startsWith('/') == true ? Uri.parse('${this.path}${path}') : path);
 
   /// Get a [JsonSchema] from the dynamicParent with the given anchor. Returns null if none exists.
   JsonSchema? resolveDynamicAnchor(String dynamicAnchor, {JsonSchema? dynamicParent}) =>

--- a/test/unit/json_schema/resolve_path_test.dart
+++ b/test/unit/json_schema/resolve_path_test.dart
@@ -21,12 +21,14 @@ main() {
         'baz': {
           '\$ref': '#a_anchor',
           'properties': {
-            'findMe': {'const': 'is found'}
+            'findMe': {'const': 'is found nested'}
           }
-        }
+        },
+        'findMe': {'const': 'is found at root'}
       }
     }, schemaVersion: SchemaVersion.draft2020_12);
   });
+
   group('Resolve path', () {
     test('ref resolved immediately when it is the only property.', () {
       var ref = testSchema.resolvePath(Uri.parse('#/properties/foo'));
@@ -41,7 +43,7 @@ main() {
 
     test('should continue resolving in the current node even if there is a ref', () {
       final ref = testSchema.resolvePath(Uri.parse('#/properties/baz/properties/findMe'));
-      expect(ref.constValue, 'is found');
+      expect(ref.constValue, 'is found nested');
     });
 
     test('should follow the ref and continue resolving', () {
@@ -84,6 +86,20 @@ main() {
         }
       }, schemaVersion: SchemaVersion.draft2020_12);
       expect(() => schema.resolvePath(Uri.parse('#/properties/Q/a')), throwsException);
+    });
+
+    test('should resolve relative path from resolved sub schema', () {
+      final subSchema = testSchema.resolvePath(Uri.parse('#/properties/baz'));
+      final superSubSchema = subSchema.resolvePath(Uri.parse('/properties/findMe'));
+
+      expect(superSubSchema.constValue, 'is found nested');
+    });
+
+    test('should resolve root document path from root schema', () {
+      final subSchema = testSchema.resolvePath(Uri.parse('#/properties/baz'));
+      final superSubSchema = subSchema.resolvePath(Uri.parse('#/properties/findMe'));
+
+      expect(superSubSchema.constValue, 'is found at root');
     });
   });
 }


### PR DESCRIPTION
## Ultimate problem:
we don't `resolvePath` on relative refs (i.e. /items vs #/items)

## How it was fixed:
Look for `/` in resolvePath to see if there is a relative path. If so append it to the current schema's path. If not, pass in the unchanged argument path.

## Testing suggestions:
Two tests added for both relative and root paths.

## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf