### PR TITLE
RM-196228 Release json_schema 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+## 5.0.2
+- Add an `JsonSchema.empty({SchemaVersion schemaVersion})` constructor
+- Allow resolving relative refs via `JsonSchema.resolvePath()`
+
 ## 5.0.1
 - Clean up pubspec, add .pubignore
+
 ## 5.0.0
 - Bump minimum Dart SDK version to 2.12.0
 - Migration to null safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-## 5.0.2
-- Add an `JsonSchema.empty({SchemaVersion schemaVersion})` constructor
-- Allow resolving relative refs via `JsonSchema.resolvePath()`
-
 ## 5.0.1
-- Clean up pubspec, add .pubignore
+- Add an `JsonSchema.empty({SchemaVersion schemaVersion})` constructor
 
 ## 5.0.0
+- Clean up pubspec, add .pubignore
 - Bump minimum Dart SDK version to 2.12.0
 - Migration to null safety
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 5.0.0
+version: 5.0.1
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Minor cleanup](https://github.com/Workiva/json_schema/pull/158)
	* [feat(package): add empty constructor for convenience](https://github.com/Workiva/json_schema/pull/161)


Requested by: @michaelcarter-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/5.0.0...Workiva:release_json_schema_5.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/5.0.0...5.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?repo_name=Workiva%2Fjson_schema&pull_number=163)