### PR TITLE
chore(package): widen range on http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  http: ^0.13.4
+  http: ">=0.13.4 <2.0.0"
   logging: ^1.0.0
   rfc_6901: ^0.1.0
   uri: '>=0.11.1 <2.0.0'


### PR DESCRIPTION
## Ultimate problem:
- Consumers need to be able to use json_schema with http 1.0

## How it was fixed:
- Widen the range so that both sub-1 and 1.0 are supported.

## Testing suggestions:


## Potential areas of regression:



---

> __FYA:__ @michaelcarter-wf