### PR TITLE
3546 Added publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      # Releases
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  create-sbom-release-asset:
+    Name: Create SBOM Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish SBOM to Release Assets
+        with:
+          path: ./
+          format: cyclonedx-json
+  publish:
+    Name: Publish to pub.dev
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## Ultimate problem:

This PR addresses two problems:

- Publishing the SBOM as a release asset
- Automatically publishing to pub.dev
