### PR TITLE
Avoid unnecessary null pointer exception if reference schema is given

### DIFF
--- a/lib/src/json_schema/json_schema.dart
+++ b/lib/src/json_schema/json_schema.dart
@@ -305,7 +305,10 @@ class JsonSchema {
       _customFormats = customFormats;
       _rootMemomizedPathResults = {};
       try {
-        _fetchedFromUriBase = JsonSchemaUtils.getBaseFromFullUri(_fetchedFromUri!);
+        // Only fetch the base if given
+        if (_fetchedFromUri != null) {
+          _fetchedFromUriBase = JsonSchemaUtils.getBaseFromFullUri(_fetchedFromUri!);
+        }
       } catch (e) {
         // ID base can't be set for schemes other than HTTP(S).
         // This is expected behavior.


### PR DESCRIPTION
## Ultimate problem:

When running an application using json_schema with debugger, I tend to break on every exception. The json_schema initialization unnecessarily tried to parse the contents of `_fetchedFromUri`, which throws when this value is null.

## How it was fixed:

I added an extra null check to avoid `JsonSchemaUtils.getBaseFromFullUri` call when the parameter is not given.

## Testing suggestions:

## Potential areas of regression:

None identified.


