### PR TITLE
Mark an `additionalProperty` as evaluated.

### DIFF
--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -530,17 +530,19 @@ class Validator {
         }
       });
 
-      if (!propCovered) {
+      if (propCovered) {
+        _addEvaluatedProp(newInstance);
+      } else {
         final additionalPropertiesSchema = schema.additionalPropertiesSchema;
         if (additionalPropertiesSchema != null) {
           _validate(additionalPropertiesSchema, newInstance);
+          _addEvaluatedProp(newInstance);
         } else if (propMustValidate) {
-          _err('unallowed additional property $k', instance.path, '${schema.path!}/additionalProperties');
+          _err('unallowed additional property $k', instance.path,
+              '${schema.path!}/additionalProperties');
         } else if (schema.additionalPropertiesBool == true) {
           _addEvaluatedProp(newInstance);
         }
-      } else {
-        _addEvaluatedProp(newInstance);
       }
     });
   }

--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -538,8 +538,7 @@ class Validator {
           _validate(additionalPropertiesSchema, newInstance);
           _addEvaluatedProp(newInstance);
         } else if (propMustValidate) {
-          _err('unallowed additional property $k', instance.path,
-              '${schema.path!}/additionalProperties');
+          _err('unallowed additional property $k', instance.path, '${schema.path!}/additionalProperties');
         } else if (schema.additionalPropertiesBool == true) {
           _addEvaluatedProp(newInstance);
         }

--- a/test/JSON-Schema-Test-Suite/tests/draft2020-12/unevaluatedProperties.json
+++ b/test/JSON-Schema-Test-Suite/tests/draft2020-12/unevaluatedProperties.json
@@ -1307,5 +1307,22 @@
                 "valid": false
             }
         ]
-    }
+    },
+    {
+      "description": "additionalProperties",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {"type": "object"},
+        "unevaluatedProperties": false
+      },
+      "tests": [
+       {
+          "description": "are evaluated",
+          "data": {
+            "anyKey": {}
+          },
+          "valid": true
+       }
+    ]
+  }
 ]

--- a/test/unit/specification_tests.dart
+++ b/test/unit/specification_tests.dart
@@ -38152,7 +38152,24 @@ Map<String, String> specificationTests = {
                 "valid": false
             }
         ]
-    }
+    },
+    {
+      "description": "additionalProperties",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {"type": "object"},
+        "unevaluatedProperties": false
+      },
+      "tests": [
+       {
+          "description": "are evaluated",
+          "data": {
+            "anyKey": {}
+          },
+          "valid": true
+       }
+    ]
+  }
 ]
 """,
   "/draft2020-12/uniqueItems.json": r"""[
@@ -78197,7 +78214,24 @@ Map<String, String> specificationTests = {
                 "valid": false
             }
         ]
-    }
+    },
+    {
+      "description": "additionalProperties",
+      "schema": {
+        "type": "object",
+        "additionalProperties": {"type": "object"},
+        "unevaluatedProperties": false
+      },
+      "tests": [
+       {
+          "description": "are evaluated",
+          "data": {
+            "anyKey": {}
+          },
+          "valid": true
+       }
+    ]
+  }
 ]
 """,
   "/latest/uniqueItems.json": r"""[


### PR DESCRIPTION
## Ultimate problem:

Reported in #190, a property should count as evaluated if it's an `additionalProperty`.

## How it was fixed:

Call `_addEvaluatedProp` when doing validation of an `additionalProperty`.

## Testing suggestions:

Added a test.

## Potential areas of regression:

Are there cases where an additional property is validated where it _shouldn't_ count as evaluated?