### PR TITLE
RM-252173 Release json_schema 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.2.0
+- [Avoid unnecessary null pointer exception if reference schema is given](https://github.com/Workiva/json_schema/pull/188)
+- [Fix ValidationResults.toString().](https://github.com/Workiva/json_schema/pull/189)
+- [Mark an `additionalProperty` as evaluated.](https://github.com/Workiva/json_schema/pull/191)
+- [Export ValidationResults as part of the public API](https://github.com/Workiva/json_schema/pull/192)
+
 ## 5.1.2
 - Widen range on `http` to include 1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 5.1.7
+version: 5.2.0
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Avoid unnecessary null pointer exception if reference schema is given](https://github.com/Workiva/json_schema/pull/188)
	* [Fix ValidationResults.toString().](https://github.com/Workiva/json_schema/pull/189)
	* [Mark an `additionalProperty` as evaluated.](https://github.com/Workiva/json_schema/pull/191)
	* [export ValidationResults](https://github.com/Workiva/json_schema/pull/192)
	* [Fix formatting](https://github.com/Workiva/json_schema/pull/193)


Requested by: @joecotton-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/json_schema/compare/5.1.7...Workiva:release_json_schema_5.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/json_schema/compare/5.1.7...5.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5466858621239296/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5466858621239296/?repo_name=Workiva%2Fjson_schema&pull_number=195)