### PR TITLE
Avoid nullable `schemaPath` and `instancePath`

### DIFF
--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -58,16 +58,16 @@ class ValidationError {
   ValidationError._(this.instancePath, this.schemaPath, this.message);
 
   /// Path in the instance data to the key where this error occurred
-  String? instancePath;
+  String instancePath;
 
   /// Path to the key in the schema containing the rule that produced this error
-  String? schemaPath;
+  String schemaPath;
 
   /// A human-readable message explaining why validation failed
   String message;
 
   @override
-  toString() => '${instancePath!.isEmpty ? '# (root)' : instancePath}: $message';
+  toString() => '${instancePath.isEmpty ? '# (root)' : instancePath}: $message';
 }
 
 /// Initialized with schema, validates instances against it
@@ -855,14 +855,14 @@ class Validator {
     return oldParent;
   }
 
-  void _err(String msg, String? instancePath, String schemaPath) {
+  void _err(String msg, String instancePath, String schemaPath) {
     schemaPath = schemaPath.replaceFirst('#', '');
     _errors.add(ValidationError._(instancePath, schemaPath, msg));
     if (!_reportMultipleErrors) throw FormatException(msg);
   }
 
-  void _warn(String msg, String? instancePath, String? schemaPath) {
-    schemaPath = schemaPath?.replaceFirst('#', '');
+  void _warn(String msg, String instancePath, String schemaPath) {
+    schemaPath = schemaPath.replaceFirst('#', '');
     _warnings.add(ValidationError._(instancePath, schemaPath, msg));
   }
 


### PR DESCRIPTION
## Ultimate problem:

`schemaPath` and `instancePath` on `ValidationError` is never `null`, so users shouldn't need to check for `null`.

## How it was fixed:

`schemaPath` and `instancePath` was made non-nullable.

## Testing suggestions:

N/A.

## Potential areas of regression:

nits:
 * Users who access `schemaPath` or `instancePath` may get a warning, if they were doing null checks (most probably where). This warning is likely harmless and easy to fix by removing the unnecessary null check.
 * Users who made a class that implements `ValidationError` may rely on `instancePath` and `schemaPath` being nullable.
   However:
   * It's unlikely that implementing `ValidationError` is common (the constructor is private, so it was probably not intended for subclassing).
   * `ValidationError` should probably be a made a `final class ValidationError`.

