### PR TITLE
Add `lib/fix_data.yaml` for automatic migration with `dart fix`.

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -38,4 +38,7 @@ jobs:
       - name: Publish - dry run
         if: ${{ matrix.sdk == 'stable' }}
         run: dart pub publish --dry-run --skip-validation
-
+      - name: Test 'dart fix'
+        # if one of these tests stops working in a future Dart SDK, it may be
+        # fine to keep entries in lib/fix_data.yaml and just remove the tests.
+        run: dart fix --compare-to-golden test_fixes/

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,0 +1,22 @@
+version: 1
+transforms:
+- title: Rename to validate
+  date: 2024-10-15
+  element:
+    uris:
+    - json_schema.dart
+    method: validateWithResults
+    inClass: Validator
+  changes:
+  - kind: rename
+    newName: validate
+- title: Rename to validate
+  date: 2024-10-15
+  element:
+    uris:
+    - json_schema.dart
+    method: validateWithResults
+    inClass: JsonSchema
+  changes:
+  - kind: rename
+    newName: validate

--- a/test_fixes/rename_to_validate.dart
+++ b/test_fixes/rename_to_validate.dart
@@ -1,0 +1,8 @@
+import 'package:json_schema/json_schema.dart';
+
+void main() {
+  final schema = JsonSchema.empty();
+  schema.validateWithResults(null);
+  final validator = Validator(schema);
+  validator.validateWithResults(null);
+}

--- a/test_fixes/rename_to_validate.dart.expect
+++ b/test_fixes/rename_to_validate.dart.expect
@@ -1,0 +1,8 @@
+import 'package:json_schema/json_schema.dart';
+
+void main() {
+  final schema = JsonSchema.empty();
+  schema.validate(null);
+  final validator = Validator(schema);
+  validator.validate(null);
+}


### PR DESCRIPTION
These fixes will also show up as "quick fixes" in IDEs. Users do not need to run `dart fix --apply` manually.

**Example:**
```dart
import 'package:json_schema/json_schema.dart';

void main() {
  final schema = JsonSchema.empty();
  schema.validateWithResults(null);
  final validator = Validator(schema);
  validator.validateWithResults(null);
}
```

Will be updated by `dart fix --apply` to:
```dart
import 'package:json_schema/json_schema.dart';

void main() {
  final schema = JsonSchema.empty();
  schema.validate(null);
  final validator = Validator(schema);
  validator.validate(null);
}
```

## Ultimate problem:
`@Deprecated` message on `validateWithResults` was not automatically migrated.

## How it was fixed:
Added `lib/fix_data.yaml` with [data driven fixes](https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md#test-folder).

## Testing suggestions:
It's possible to make a `test_fixes/` folder with golden files that can be tested with `dart fix --compare-to-golden` however this is probably overkill. See [testing](https://github.com/flutter/flutter/blob/master/docs/contributing/Data-driven-Fixes.md#testing).

I manually tested this. There is probably no harm in leaving this in place even after 5.0 is released, as it'll probably still facilitate quick fixes for anyone upgrading.


## Potential areas of regression:

If these data driven fixes stop working, they aren't likely to cause much harm (they simply won't cause fixes to be suggested).


------

I mostly made this because I think `fix_data.yaml` is too cool, not to be used :rofl: 