### PR TITLE
Avoid empty `instancePath` when `propertyNames` is violated

### DIFF
--- a/lib/src/json_schema/validator.dart
+++ b/lib/src/json_schema/validator.dart
@@ -153,6 +153,9 @@ class Validator {
         throw ArgumentError('JSON instance provided to validate is not valid JSON.');
       }
     }
+    if (data is! Instance) {
+      data = Instance(data);
+    }
 
     _reportMultipleErrors = reportMultipleErrors;
     _errors = [];
@@ -511,7 +514,8 @@ class Validator {
       // Validate property names against the provided schema, if any.
       final propertyNamesSchema = schema.propertyNamesSchema;
       if (propertyNamesSchema != null) {
-        _validate(propertyNamesSchema, k);
+        final propertyNamesInstance = Instance(k, path: '${instance.path}/$k');
+        _validate(propertyNamesSchema, propertyNamesInstance);
       }
 
       final newInstance = Instance(v, path: '${instance.path}/$k');
@@ -660,11 +664,7 @@ class Validator {
     _refsEncountered.remove(irp);
   }
 
-  void _validate(JsonSchema schema, dynamic instance) {
-    if (instance is! Instance) {
-      instance = Instance(instance);
-    }
-
+  void _validate(JsonSchema schema, Instance instance) {
     if (schema.unevaluatedItems != null) {
       var length = instance.data is List ? instance.data.length : 0;
       _pushEvaluatedItemsContext(length);

--- a/test/unit/json_schema/validation_error_test.dart
+++ b/test/unit/json_schema/validation_error_test.dart
@@ -495,6 +495,27 @@ void main() {
       expect(errors[0].message, contains('type'));
     });
 
+    test('Object propertyNames', () {
+      final schema = createObjectSchema({
+        'propertyNames': {
+          'maxLength': 7,
+        }
+      });
+      final errors = schema.validate({
+        'someKey': {
+          'foo': true,
+          'foobar': true,
+          // property name "foobarbar" is longer maxLength of 7
+          'foobarbar': true,
+        }
+      }).errors;
+
+      expect(errors.length, 1);
+      expect(errors[0].instancePath, '/someKey/foobarbar');
+      expect(errors[0].schemaPath, '/properties/someKey/propertyNames');
+      expect(errors[0].message, contains('maxLength'));
+    });
+
     test('Object additional properties not allowed', () {
       final schema = createObjectSchema({
         'properties': {


### PR DESCRIPTION
## Ultimate problem:

When validating a schema with the [`propertyNames` applicator](https://json-schema.org/understanding-json-schema/reference/object#propertyNames) any errors produced had an empty `instancePath`.

## How it was fixed:

This makes `_validate` take an `Instance` object instead of dynamic. And instead forces the callers to convert any values to `Instance` objects.

This is probably a good idea because:
 * Caller is the only one who can construct the `instancePath`.
 * It avoids a lot of unnecessary `instance is! Instance` checks :rocket: 

While fixing this I discovered that `propertyNames` errors were reported with an empty `instancePath`. Which could cause confusion for anyone trying to display the error.


## Testing suggestions:

Test case included in PR.

## Potential areas of regression:

Anyone depending on current behavior could be affected.
Most likely an empty `instancePath` is not what anyone is expecting.