### PR TITLE
feat: add 'idn-email' format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 5.2.1
-
-- [Add 'idn-email' format validation](https://github.com/Workiva/json_schema/pull/204)
-
 ## 5.2.0
 - [Avoid unnecessary null pointer exception if reference schema is given](https://github.com/Workiva/json_schema/pull/188)
 - [Fix ValidationResults.toString().](https://github.com/Workiva/json_schema/pull/189)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.1
+
+- [Add 'idn-email' format validation]()
+
 ## 5.2.0
 - [Avoid unnecessary null pointer exception if reference schema is given](https://github.com/Workiva/json_schema/pull/188)
 - [Fix ValidationResults.toString().](https://github.com/Workiva/json_schema/pull/189)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.2.1
 
-- [Add 'idn-email' format validation]()
+- [Add 'idn-email' format validation](https://github.com/Workiva/json_schema/pull/204)
 
 ## 5.2.0
 - [Avoid unnecessary null pointer exception if reference schema is given](https://github.com/Workiva/json_schema/pull/188)

--- a/lib/src/json_schema/formats/idn_email_validator.dart
+++ b/lib/src/json_schema/formats/idn_email_validator.dart
@@ -1,7 +1,9 @@
 import 'package:json_schema/src/json_schema/models/validation_context.dart';
+import 'package:rfc_6531/rfc_6531.dart' as rfc_6531;
 
 ValidationContext defaultIdnEmailValidator(ValidationContext context, String instanceData) {
-  // No maintained dart packages exist to validate RFC6531,
-  // and it's too complex for a regex, so best effort is to pass for now.
+  if (rfc_6531.regExp.firstMatch(instanceData) == null) {
+    context.addError('"idn-email" format not accepted $instanceData');
+  }
   return context;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 5.2.1
+version: 5.2.0
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_schema
-version: 5.2.0
+version: 5.2.1
 description: JSON Schema implementation in Dart
 homepage: https://github.com/workiva/json_schema
 
@@ -10,6 +10,7 @@ dependencies:
   collection: ^1.15.0
   http: ">=0.13.4 <2.0.0"
   logging: ^1.0.0
+  rfc_6531: ^1.0.0
   rfc_6901: '>=0.1.0 <0.3.0'
   uri: '>=0.11.1 <2.0.0'
 


### PR DESCRIPTION
## Ultimate problem:
Lack of built-in 'idn-email' format validation.

## How it was fixed:
It was fixed using `rfc_6531` package.

## Testing suggestions:
Testing is built-in into `rfc_6531` package.

## Potential areas of regression:
N/A.


