### PR TITLE
WADMIN-9939 Make enum type checks less restrictive

### DIFF
--- a/lib/src/json_schema/utils/type_validators.dart
+++ b/lib/src/json_schema/utils/type_validators.dart
@@ -18,7 +18,7 @@ class TypeValidators {
 
   static List uniqueList(String key, dynamic value) {
     int i = 0;
-    final List enumValues = TypeValidators.nonEmptyList(key, value);
+    final List enumValues = TypeValidators.list(key, value);
     for (final _ in enumValues) {
       for (int j = i + 1; j < enumValues.length; j++) {
         if (DeepCollectionEquality().equals(enumValues[i], enumValues[j])) {

--- a/test/custom/invalid_schemas/draft4/enum.json
+++ b/test/custom/invalid_schemas/draft4/enum.json
@@ -16,10 +16,6 @@
         "schema" : { "enum" : {} }
     },
     {
-        "description" : "enum: must be a non-empty array",
-        "schema" : { "enum" : [] }
-    },
-    {
         "description" : "enum: elements must be unique",
         "schema" : { "enum" : [3,4,3] }
     },


### PR DESCRIPTION
## Ultimate problem:
Unique list does not mean that a list needs values. 

The JSON Schema spec doesn't even require that these values MUST be unique, but that is a different issue: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#enum

## How it was fixed:
Make empty lists valid for enum types

## Testing suggestions:


## Potential areas of regression:



