### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Workiva/configurable-ui
+* @Workiva/fresh


### PR DESCRIPTION
update code owners to frontend shell team

## Ultimate problem:
Code owners of this repo are still set as old config-ui team, but the frontend shell team needs to be the owners




